### PR TITLE
Small config and documentation tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: deps lint test add-license check-license circleci-local validator \
 	watch-blocks view-block-benchmarks view-account-benchmarks salus
 LICENCE_SCRIPT=addlicense -c "Coinbase, Inc." -l "apache" -v
-SERVER_ADDR=http://localhost:10000
+SERVER_URL?=http://localhost:10000
+LOG_TRANSACTIONS?=false
+LOG_BENCHMARKS?=true
 
 deps:
 	go get ./...
@@ -27,17 +29,17 @@ circleci-local:
 salus:
 	docker run --rm -t -v ${PWD}:/home/repo coinbase/salus
 
-validator:
+validate:
 	docker build -t rosetta-validator .; \
 	docker run \
 		-v ${PWD}/validator-data:/data \
 		-e DATA_DIR="/data" \
-		-e SERVER_ADDR="${SERVER_ADDR}" \
+		-e SERVER_URL="${SERVER_URL}" \
 		-e BLOCK_CONCURRENCY="32" \
 		-e TRANSACTION_CONCURRENCY="8" \
 		-e ACCOUNT_CONCURRENCY="8" \
-		-e LOG_TRANSACTIONS="false" \
-		-e LOG_BENCHMARKS="true" \
+		-e LOG_TRANSACTIONS="${LOG_TRANSACTIONS}" \
+		-e LOG_BENCHMARKS="${LOG_BENCHMARKS}" \
 		--network host \
 		rosetta-validator \
 		rosetta-validator;

--- a/README.md
+++ b/README.md
@@ -18,15 +18,19 @@ and wallets to integrate with much less communication overhead
 and network-specific work.
 
 ## Run the Validator
+
+The validator needs the URL of the Rosetta server configured. This can be set
+as an environment variable named `SERVER_URL`, passed as an argument to make eg `make SERVER_URL=<server url> validate`
+or editing `Makefile` itself.
+
 1. Start your Rosetta Server (and the blockchain node it connects to if it is
 not a single binary.
-2. Modify the `Makefile` to point to the correct Rosetta Server port.
-3. Start the validator using `make validator`.
-4. Examine processed blocks using `make watch-blocks`. You can also print transactions
-by setting `LOG_TRANSACTIONS="true"` in the `Makefile`.
-5. Watch for errors in the processing logs. Any error will cause the validator to stop.
-6. Analyze benchmarks from `worker-data/block_benchmarks.csv` and
-  `worker-data/account_benchmarks.csv` by setting `LOG_BENCHMARKS="true"` in the `Makefile`.
+2. Start the validator using `make SERVER_URL=<server URL> validate`.
+3. Examine processed blocks using `make watch-blocks`. You can also print transactions
+by setting `LOG_TRANSACTIONS="true"` in the environment or as a `make` argument.
+4. Watch for errors in the processing logs. Any error will cause the validator to stop.
+5. Analyze benchmarks from `validator-data/block_benchmarks.csv` and
+  `validator-data/account_benchmarks.csv` by setting `LOG_BENCHMARKS="true"` in the environment or as a `make` argument.
 
 _There is no additional setting required to support blockchains with reorgs. This
 is handled automatically!_

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ import (
 
 type config struct {
 	DataDir                string `env:"DATA_DIR,required"`
-	ServerAddr             string `env:"SERVER_ADDR,required"`
+	ServerURL              string `env:"SERVER_URL,required"`
 	BlockConcurrency       uint64 `env:"BLOCK_CONCURRENCY,required"`
 	TransactionConcurrency uint64 `env:"TRANSACTION_CONCURRENCY,required"`
 	AccountConcurrency     int    `env:"ACCOUNT_CONCURRENCY,required"`
@@ -52,7 +52,7 @@ func main() {
 
 	fetcher := fetcher.New(
 		ctx,
-		cfg.ServerAddr,
+		cfg.ServerURL,
 		"rosetta-validator",
 		&http.Client{
 			Timeout: 10 * time.Second,


### PR DESCRIPTION
Follow 12 factor app patterns: Enable setting config via CLI and env vars.

Change the target name `make validator` to `make validate` since it actually runs the validation (verb) as opposed to just building a thing (noun).

Update docs.