### PR TITLE
Bootstrap Account Balances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 validator-data
+rosetta-validator

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ salus:
 validate:
 	docker build -t rosetta-validator .; \
 	docker run \
+		--rm \
 		-v ${PWD}/validator-data:/data \
 		-e DATA_DIR="/data" \
 		-e SERVER_URL="${SERVER_URL}" \

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LICENCE_SCRIPT=addlicense -c "Coinbase, Inc." -l "apache" -v
 SERVER_URL?=http://localhost:10000
 LOG_TRANSACTIONS?=false
 LOG_BENCHMARKS?=true
+BOOTSTRAP_BALANCES?=false
 
 deps:
 	go get ./...
@@ -41,6 +42,7 @@ validate:
 		-e ACCOUNT_CONCURRENCY="8" \
 		-e LOG_TRANSACTIONS="${LOG_TRANSACTIONS}" \
 		-e LOG_BENCHMARKS="${LOG_BENCHMARKS}" \
+		-e BOOTSTRAP_BALANCES="${BOOTSTRAP_BALANCES}" \
 		--network host \
 		rosetta-validator \
 		rosetta-validator;

--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ and wallets to integrate with much less communication overhead
 and network-specific work.
 
 ## Run the Validator
-
-The validator needs the URL of the Rosetta server configured. This can be set
-as an environment variable named `SERVER_URL`, passed as an argument to make eg `make SERVER_URL=<server url> validate`
-or editing `Makefile` itself.
-
 1. Start your Rosetta Server (and the blockchain node it connects to if it is
 not a single binary.
 2. Start the validator using `make SERVER_URL=<server URL> validate`.
@@ -30,10 +25,25 @@ not a single binary.
 by setting `LOG_TRANSACTIONS="true"` in the environment or as a `make` argument.
 4. Watch for errors in the processing logs. Any error will cause the validator to stop.
 5. Analyze benchmarks from `validator-data/block_benchmarks.csv` and
-  `validator-data/account_benchmarks.csv` by setting `LOG_BENCHMARKS="true"` in the environment or as a `make` argument.
+`validator-data/account_benchmarks.csv` by setting `LOG_BENCHMARKS="true"` in
+the environment or as a `make` argument.
 
-_There is no additional setting required to support blockchains with reorgs. This
-is handled automatically!_
+### Setting the Server URL
+The validator needs the URL of the Rosetta server configured. This can be set
+as an environment variable named `SERVER_URL`, passed as an argument to make
+(ex: `make SERVER_URL=<server url> validate`) or editing `Makefile` itself.
+
+### Bootstrapping Balances
+Blockchains that set balances in genesis must create a `bootstrap_balances.csv`
+file in the `/validator-data` directory and pass `BOOTSTRAP_BALANCES=true` as an
+argument to make. If balances are not bootsrapped and balances are set in genesis,
+reconciliation will fail.
+
+There is an example file in `examples/bootstrap_balances.csv`.
+
+### Re-orgable Blockchains
+There is no additional setting required to support blockchains with reorgs. This
+is handled automatically!
 
 ## Development
 * `make deps` to install dependencies

--- a/examples/bootstrap_balances.csv
+++ b/examples/bootstrap_balances.csv
@@ -1,0 +1,2 @@
+AccountIdentifier_address,Amount_value,Currency_symbol,Currency_decimals
+1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,5000000000,BTC,8

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/caarlos0/env v3.5.0+incompatible
-	github.com/coinbase/rosetta-sdk-go v0.0.1
+	github.com/coinbase/rosetta-sdk-go v0.0.3
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger v1.6.0
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEe
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/coinbase/rosetta-sdk-go v0.0.1 h1:s6oBsnXCEmTvZxNTHZ4+sjSSWEGCtCBO7kTcED3WILc=
 github.com/coinbase/rosetta-sdk-go v0.0.1/go.mod h1:T7kbh9AOzlxEITJGt2Fu854vxg/yEjy5MsR1woSM5aI=
+github.com/coinbase/rosetta-sdk-go v0.0.3 h1:raFtDs4u0P7h7H+HzHpGQzDYctEpL80nx3e/EY4esXk=
+github.com/coinbase/rosetta-sdk-go v0.0.3/go.mod h1:T7kbh9AOzlxEITJGt2Fu854vxg/yEjy5MsR1woSM5aI=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -407,6 +407,7 @@ func (b *BlockStorage) UpdateBalance(
 		if !ok {
 			return fmt.Errorf("%s is not an integer", amount.Value)
 		}
+
 		if newVal.Sign() == -1 {
 			return fmt.Errorf(
 				"%w %+v for %+v at %+v",

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ type config struct {
 	AccountConcurrency     int    `env:"ACCOUNT_CONCURRENCY,required"`
 	LogTransactions        bool   `env:"LOG_TRANSACTIONS,required"`
 	LogBenchmarks          bool   `env:"LOG_BENCHMARKS,required"`
+	BootstrapBalances      bool   `env:"BOOTSTRAP_BALANCES,required"`
 }
 
 func main() {
@@ -78,6 +79,17 @@ func main() {
 	}
 
 	blockStorage := storage.NewBlockStorage(ctx, localStore)
+	if cfg.BootstrapBalances {
+		err = blockStorage.BootstrapBalances(
+			ctx,
+			cfg.DataDir,
+			networkResponse.NetworkStatus.NetworkInformation.GenesisBlockIdentifier,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	logger := logger.NewLogger(cfg.DataDir, cfg.LogTransactions, cfg.LogBenchmarks)
 
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
### Motivation
The reconciler returns errors for blockchains that set account balances in the genesis file.

### Solution
It is now possible to bootstrap account balances using a provided `bootstrap_balances.csv` file.

### Miscellaneous Fixes
* Ensure that the genesis block cannot be orphaned
* Ensure the nextSyncable range is correct
* Exit if there is an error while syncing blocks before active reconciliation is enabled