### PR TITLE
Log Balance Changes and Reconciliations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,92 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: 2
-jobs:
-  build:
+version: 2.1
+executors:
+  default:
     docker:
       - image: circleci/golang:1.13
-    working_directory: /go/src/github.com/coinbase/rosetta-validator
+        user: root # go directory is owned by root
+    working_directory: /go/src/github.com/coinbase/rosetta-sdk-go
+    environment:
+      - GO111MODULE: "on"
+
+fast-checkout: &fast-checkout
+  attach_workspace:
+    at: /go
+
+jobs:
+  setup:
+    executor:
+      name: default
     steps:
       - checkout
       - run: make deps
+      - persist_to_workspace:
+          root: /go
+          paths:
+            - src
+            - bin
+            - pkg/mod/cache
+  test:
+    executor:
+      name: default
+    steps:
+      - *fast-checkout
       - run: make test
+  lint:
+    executor:
+      name: default
+    steps:
+      - *fast-checkout
+      - run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
       - run: make lint
+  check-license:
+    executor:
+      name: default
+    steps:
+      - *fast-checkout
       - run: make check-license
+  check-format:
+    executor:
+      name: default
+    steps:
+      - *fast-checkout
+      - run: make check-format
+  coverage:
+    executor:
+      name: default
+    steps:
+      - *fast-checkout
+      - run: make test-cover
+  salus:
+    machine: true
+    steps:
+      - checkout
+      - run: docker run -t -v $(pwd):/home/repo coinbase/salus
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - setup
+      - test:
+          requires:
+            - setup
+      - lint:
+          requires:
+            - setup
+      - check-license:
+          requires:
+            - setup
+      - check-format:
+          requires:
+            - setup
+      - coverage:
+          requires:
+            - setup
+      - salus
+
+notify:
+  webhooks:
+    - url: https://coveralls.io/webhook?repo_token=$COVERALLS_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ deps:
 
 lint:
 	golangci-lint run -v \
-		-E golint,misspell,gocyclo,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam,gomnd
+		-E golint,misspell,gocyclo,whitespace,goconst,gocritic,gocognit,bodyclose,unconvert,lll,unparam,gomnd
 
 format:
 	gofmt -s -w -l .

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LICENCE_SCRIPT=addlicense -c "Coinbase, Inc." -l "apache" -v
 SERVER_URL?=http://localhost:10000
 LOG_TRANSACTIONS?=true
 LOG_BENCHMARKS?=false
+LOG_BALANCES?=true
 BOOTSTRAP_BALANCES?=false
 
 deps:
@@ -42,6 +43,7 @@ validate:
 		-e ACCOUNT_CONCURRENCY="8" \
 		-e LOG_TRANSACTIONS="${LOG_TRANSACTIONS}" \
 		-e LOG_BENCHMARKS="${LOG_BENCHMARKS}" \
+		-e LOG_BALANCES="${LOG_BALANCES}" \
 		-e BOOTSTRAP_BALANCES="${BOOTSTRAP_BALANCES}" \
 		--network host \
 		rosetta-validator \

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
-.PHONY: deps lint test add-license check-license circleci-local validator \
-	watch-blocks view-block-benchmarks view-account-benchmarks salus
+.PHONY: deps lint format check-format test test-cover add-license \
+	check-license shorten-lines salus validate watch-blocks \
+	watch-transactions watch-balances watch-reconciliations \
+	view-block-benchmarks view-account-benchmarks
 LICENCE_SCRIPT=addlicense -c "Coinbase, Inc." -l "apache" -v
 TEST_SCRIPT=go test -v ./internal/...
 
-SERVER_URL?=http://localhost:10000
+SERVER_URL?=http://localhost:8080
 LOG_TRANSACTIONS?=true
 LOG_BENCHMARKS?=false
 LOG_BALANCES?=true
+LOG_RECONCILIATION?=true
 BOOTSTRAP_BALANCES?=false
 
 deps:
@@ -60,6 +63,7 @@ validate:
 		-e LOG_TRANSACTIONS="${LOG_TRANSACTIONS}" \
 		-e LOG_BENCHMARKS="${LOG_BENCHMARKS}" \
 		-e LOG_BALANCES="${LOG_BALANCES}" \
+		-e LOG_RECONCILIATION="${LOG_RECONCILIATION}" \
 		-e BOOTSTRAP_BALANCES="${BOOTSTRAP_BALANCES}" \
 		--network host \
 		rosetta-validator \
@@ -68,11 +72,14 @@ validate:
 watch-blocks:
 	tail -f ${PWD}/validator-data/blocks.txt
 
+watch-transactions:
+	tail -f ${PWD}/validator-data/transactions.txt
+
 watch-balances:
 	tail -f ${PWD}/validator-data/balances.txt
 
-watch-transactions:
-	tail -f ${PWD}/validator-data/transactions.txt
+watch-reconciliations:
+	tail -f ${PWD}/validator-data/reconciliations.txt
 
 view-block-benchmarks:
 	open ${PWD}/validator-data/block_benchmarks.csv

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ deps:
 
 lint:
 	golangci-lint run -v \
-		-E golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam,gomnd
+		-E golint,misspell,gocyclo,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam,gomnd
 
 format:
 	gofmt -s -w -l .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: deps lint test add-license check-license circleci-local validator \
 	watch-blocks view-block-benchmarks view-account-benchmarks salus
 LICENCE_SCRIPT=addlicense -c "Coinbase, Inc." -l "apache" -v
+TEST_SCRIPT=go test -v ./internal/...
+
 SERVER_URL?=http://localhost:10000
 LOG_TRANSACTIONS?=true
 LOG_BENCHMARKS?=false
@@ -10,14 +12,26 @@ BOOTSTRAP_BALANCES?=false
 deps:
 	go get ./...
 	go get github.com/stretchr/testify
-	go get golang.org/x/lint/golint
 	go get github.com/google/addlicense
+	go get github.com/segmentio/golines
+	go get github.com/mattn/goveralls
 
 lint:
-	golint ./internal/...
+	golangci-lint run -v \
+		-E golint,misspell,gocyclo,gocritic,whitespace,goconst,gocognit,bodyclose,unconvert,lll,unparam,gomnd
+
+format:
+	gofmt -s -w -l .
+
+check-format:
+	! gofmt -s -l . | read
 
 test:
-	go test -v ./internal/...
+	${TEST_SCRIPT}
+
+test-cover:	
+	${TEST_SCRIPT} -coverprofile=c.out -covermode=count
+	goveralls -coverprofile=c.out -repotoken ${COVERALLS_TOKEN}
 
 add-license:
 	${LICENCE_SCRIPT} .
@@ -25,11 +39,13 @@ add-license:
 check-license:
 	${LICENCE_SCRIPT} -check .
 
-circleci-local:
-	circleci local execute
+shorten-lines:
+	golines -w --shorten-comments internal 
 
 salus:
 	docker run --rm -t -v ${PWD}:/home/repo coinbase/salus
+
+release: add-license shorten-lines format test lint salus
 
 validate:
 	docker build -t rosetta-validator .; \
@@ -51,6 +67,12 @@ validate:
 
 watch-blocks:
 	tail -f ${PWD}/validator-data/blocks.txt
+
+watch-balances:
+	tail -f ${PWD}/validator-data/balances.txt
+
+watch-transactions:
+	tail -f ${PWD}/validator-data/transactions.txt
 
 view-block-benchmarks:
 	open ${PWD}/validator-data/block_benchmarks.csv

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 	watch-blocks view-block-benchmarks view-account-benchmarks salus
 LICENCE_SCRIPT=addlicense -c "Coinbase, Inc." -l "apache" -v
 SERVER_URL?=http://localhost:10000
-LOG_TRANSACTIONS?=false
-LOG_BENCHMARKS?=true
+LOG_TRANSACTIONS?=true
+LOG_BENCHMARKS?=false
 BOOTSTRAP_BALANCES?=false
 
 deps:

--- a/README.md
+++ b/README.md
@@ -23,13 +23,10 @@ and network-specific work.
 ## Run the Validator
 1. Start your Rosetta Server (and the blockchain node it connects to if it is
 not a single binary.
-2. Start the validator using `make SERVER_URL=<server URL> validate`.
-3. Examine processed blocks using `make watch-blocks`. You can also print transactions
-by setting `LOG_TRANSACTIONS="true"` in the environment or as a `make` argument.
-4. Watch for errors in the processing logs. Any error will cause the validator to stop.
-5. Analyze benchmarks from `validator-data/block_benchmarks.csv` and
-`validator-data/account_benchmarks.csv` by setting `LOG_BENCHMARKS="true"` in
-the environment or as a `make` argument.
+2. Start the validator using `makevalidate`.
+3. Examine processed blocks using `make watch-blocks`.
+4. Watch for errors in the processing logs. Any error will cause validation to
+stop.
 
 ### Configuration Options
 All configuration options can be set in the call to `make validate`
@@ -41,25 +38,30 @@ is handled automatically!_
 
 #### SERVER_URL
 _Default: http://localhost:8080_
+
 The URL the validator will use to access the Rosetta Server.
 
 #### LOG_TRANSACTIONS
 _Default: true_
+
 All processed transactions will be logged to `transactions.txt`. You can tail
 these logs using `watch-transactions`.
 
 #### LOG_BALANCES
 _Default: true_
+
 All processed balance changes will be logged to `balances.txt`. You can tail
 these logs using `watch-balances`.
 
 #### LOG_RECONCILIATION
 _Default: true_
+
 All reconciliation checks will be logged to `reconciliations.txt`. You can tail
 these logs using `watch-reconciliations`.
 
 #### BOOTSTRAP_BALANCES
 _Default: false_
+
 Blockchains that set balances in genesis must create a `bootstrap_balances.csv`
 file in the `/validator-data` directory and pass `BOOTSTRAP_BALANCES=true` as an
 argument to make. If balances are not bootsrapped and balances are set in genesis,
@@ -69,6 +71,7 @@ There is an example file in `examples/bootstrap_balances.csv`.
 
 #### LOG_BENCHMARKS
 _Default: false_
+
 It can be useful to observe performance characteristics of a Rosetta Server.
 When enabled, it is possible to view the latency of block and account fetches.
 Note, this naive implementation of benchmarks does not factor in request latency

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # rosetta-validator
 
-[![Coinbase](https://circleci.com/gh/coinbase/rosetta-validator/tree/master.svg?style=svg)](https://circleci.com/gh/coinbase/rosetta-validator/tree/master)
+[![Coinbase](https://circleci.com/gh/coinbase/rosetta-validator/tree/master.svg?style=shield)](https://circleci.com/gh/coinbase/rosetta-validator/tree/master)
+[![Coverage Status](https://coveralls.io/repos/github/coinbase/rosetta-validator/badge.svg)](https://coveralls.io/github/coinbase/rosetta-validator)
+[![Go Report Card](https://goreportcard.com/badge/github.com/coinbase/rosetta-validator)](https://goreportcard.com/report/github.com/coinbase/rosetta-validator)
+[![License](https://img.shields.io/github/license/coinbase/rosetta-validator.svg)](https://github.com/coinbase/rosetta-validator/blob/master/LICENSE.txt)
 
 Once you create a Rosetta Server, you'll need to test its
 performance and correctness. This validation tool makes that easy!

--- a/README.md
+++ b/README.md
@@ -31,12 +31,35 @@ by setting `LOG_TRANSACTIONS="true"` in the environment or as a `make` argument.
 `validator-data/account_benchmarks.csv` by setting `LOG_BENCHMARKS="true"` in
 the environment or as a `make` argument.
 
-### Setting the Server URL
-The validator needs the URL of the Rosetta server configured. This can be set
-as an environment variable named `SERVER_URL`, passed as an argument to make
-(ex: `make SERVER_URL=<server url> validate`) or editing `Makefile` itself.
+### Configuration Options
+All configuration options can be set in the call to `make validate`
+(ex: `make SERVER_URL=http://localhost:9999 validate`) or altered in
+the `Makefile` itself.
 
-### Bootstrapping Balances
+_There is no additional setting required to support blockchains with reorgs. This
+is handled automatically!_
+
+#### SERVER_URL
+_Default: http://localhost:8080_
+The URL the validator will use to access the Rosetta Server.
+
+#### LOG_TRANSACTIONS
+_Default: true_
+All processed transactions will be logged to `transactions.txt`. You can tail
+these logs using `watch-transactions`.
+
+#### LOG_BALANCES
+_Default: true_
+All processed balance changes will be logged to `balances.txt`. You can tail
+these logs using `watch-balances`.
+
+#### LOG_RECONCILIATION
+_Default: true_
+All reconciliation checks will be logged to `reconciliations.txt`. You can tail
+these logs using `watch-reconciliations`.
+
+#### BOOTSTRAP_BALANCES
+_Default: false_
 Blockchains that set balances in genesis must create a `bootstrap_balances.csv`
 file in the `/validator-data` directory and pass `BOOTSTRAP_BALANCES=true` as an
 argument to make. If balances are not bootsrapped and balances are set in genesis,
@@ -44,14 +67,18 @@ reconciliation will fail.
 
 There is an example file in `examples/bootstrap_balances.csv`.
 
-### Re-orgable Blockchains
-There is no additional setting required to support blockchains with reorgs. This
-is handled automatically!
+#### LOG_BENCHMARKS
+_Default: false_
+It can be useful to observe performance characteristics of a Rosetta Server.
+When enabled, it is possible to view the latency of block and account fetches.
+Note, this naive implementation of benchmarks does not factor in request latency
+due to multithreaded requests.
 
 ## Development
 * `make deps` to install dependencies
 * `make test` to run tests
 * `make lint` to lint the source code (included generated code)
+* `make release` to run one last check before opening a PR
 
 ## Correctness Checks
 This tool performs a variety of correctness checks using the Rosetta Server. If

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -69,7 +69,7 @@ const (
 	logFilePermissions = 0600
 )
 
-// Logger contains all logic to record validator ouput
+// Logger contains all logic to record validator output
 // and benchmark a Rosetta Server.
 type Logger struct {
 	logDir          string

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -416,7 +416,7 @@ func (r *Reconciler) reconcileActiveAccounts(
 		case <-ctx.Done():
 			return ctx.Err()
 		case balanceChange := <-r.acctQueue:
-			if balanceChange.NewBlock.Index < r.highWaterMark {
+			if balanceChange.Block.Index < r.highWaterMark {
 				continue
 			}
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -398,6 +398,18 @@ func (r *Reconciler) accountReconciliation(
 			simpleAccountAndCurrency(acct),
 			liveBlock.Index,
 		)
+
+		err = r.logger.ReconcileStream(
+			ctx,
+			acct.Account,
+			acct.Currency,
+			liveAmount,
+			liveBlock,
+		)
+		if err != nil {
+			return err
+		}
+
 		break
 	}
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -416,7 +416,7 @@ func (r *Reconciler) reconcileActiveAccounts(
 		case <-ctx.Done():
 			return ctx.Err()
 		case balanceChange := <-r.acctQueue:
-			if balanceChange.Block.Index < r.highWaterMark {
+			if balanceChange.NewBlock.Index < r.highWaterMark {
 				continue
 			}
 

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccountAndCurrencyExists(t *testing.T) {
+func TestContainsAccountAndCurrency(t *testing.T) {
 	currency1 := &rosetta.Currency{
 		Symbol:   "Blah",
 		Decimals: 2,
@@ -36,14 +36,14 @@ func TestAccountAndCurrencyExists(t *testing.T) {
 		Symbol:   "Blah2",
 		Decimals: 2,
 	}
-	accts := []*AccountAndCurrency{
-		&AccountAndCurrency{
+	accts := []*storage.BalanceChange{
+		&storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "test",
 			},
 			Currency: currency1,
 		},
-		&AccountAndCurrency{
+		&storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "cool",
 				SubAccount: &rosetta.SubAccountIdentifier{
@@ -52,7 +52,7 @@ func TestAccountAndCurrencyExists(t *testing.T) {
 			},
 			Currency: currency1,
 		},
-		&AccountAndCurrency{
+		&storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "cool",
 				SubAccount: &rosetta.SubAccountIdentifier{
@@ -67,7 +67,7 @@ func TestAccountAndCurrencyExists(t *testing.T) {
 	}
 
 	t.Run("Non-existent account", func(t *testing.T) {
-		assert.False(t, ContainsAccountAndCurrency(accts, &AccountAndCurrency{
+		assert.False(t, containsAccountAndCurrency(accts, &storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "blah",
 			},
@@ -76,7 +76,7 @@ func TestAccountAndCurrencyExists(t *testing.T) {
 	})
 
 	t.Run("Basic account", func(t *testing.T) {
-		assert.True(t, ContainsAccountAndCurrency(accts, &AccountAndCurrency{
+		assert.True(t, containsAccountAndCurrency(accts, &storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "test",
 			},
@@ -85,7 +85,7 @@ func TestAccountAndCurrencyExists(t *testing.T) {
 	})
 
 	t.Run("Basic account with bad currency", func(t *testing.T) {
-		assert.False(t, ContainsAccountAndCurrency(accts, &AccountAndCurrency{
+		assert.False(t, containsAccountAndCurrency(accts, &storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "test",
 			},
@@ -94,7 +94,7 @@ func TestAccountAndCurrencyExists(t *testing.T) {
 	})
 
 	t.Run("Account with subaccount", func(t *testing.T) {
-		assert.True(t, ContainsAccountAndCurrency(accts, &AccountAndCurrency{
+		assert.True(t, containsAccountAndCurrency(accts, &storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "cool",
 				SubAccount: &rosetta.SubAccountIdentifier{
@@ -106,7 +106,7 @@ func TestAccountAndCurrencyExists(t *testing.T) {
 	})
 
 	t.Run("Account with subaccount and metadata", func(t *testing.T) {
-		assert.True(t, ContainsAccountAndCurrency(accts, &AccountAndCurrency{
+		assert.True(t, containsAccountAndCurrency(accts, &storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "cool",
 				SubAccount: &rosetta.SubAccountIdentifier{
@@ -121,7 +121,7 @@ func TestAccountAndCurrencyExists(t *testing.T) {
 	})
 
 	t.Run("Account with subaccount and unique metadata", func(t *testing.T) {
-		assert.False(t, ContainsAccountAndCurrency(accts, &AccountAndCurrency{
+		assert.False(t, containsAccountAndCurrency(accts, &storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "cool",
 				SubAccount: &rosetta.SubAccountIdentifier{
@@ -207,14 +207,14 @@ func TestExtractAmount(t *testing.T) {
 			},
 		}
 
-		badAcct = &AccountAndCurrency{
+		badAcct = &storage.BalanceChange{
 			Account: &rosetta.AccountIdentifier{
 				Address: "no acct",
 			},
 			Currency: currency1,
 		}
 
-		badCurr = &AccountAndCurrency{
+		badCurr = &storage.BalanceChange{
 			Account: account1,
 			Currency: &rosetta.Currency{
 				Symbol:   "no curr",
@@ -236,7 +236,7 @@ func TestExtractAmount(t *testing.T) {
 	})
 
 	t.Run("Simple account", func(t *testing.T) {
-		result, err := extractAmount(balances, &AccountAndCurrency{
+		result, err := extractAmount(balances, &storage.BalanceChange{
 			Account:  account1,
 			Currency: currency1,
 		})
@@ -245,7 +245,7 @@ func TestExtractAmount(t *testing.T) {
 	})
 
 	t.Run("SubAccount", func(t *testing.T) {
-		result, err := extractAmount(balances, &AccountAndCurrency{
+		result, err := extractAmount(balances, &storage.BalanceChange{
 			Account:  account2,
 			Currency: currency2,
 		})
@@ -320,7 +320,7 @@ func TestCompareBalance(t *testing.T) {
 	t.Run("No head block yet", func(t *testing.T) {
 		difference, headIndex, err := reconciler.CompareBalance(
 			ctx,
-			&AccountAndCurrency{
+			&storage.BalanceChange{
 				Account:  account1,
 				Currency: currency1,
 			},
@@ -342,7 +342,7 @@ func TestCompareBalance(t *testing.T) {
 	t.Run("Live block is ahead of head block", func(t *testing.T) {
 		difference, headIndex, err := reconciler.CompareBalance(
 			ctx,
-			&AccountAndCurrency{
+			&storage.BalanceChange{
 				Account:  account1,
 				Currency: currency1,
 			},
@@ -372,7 +372,7 @@ func TestCompareBalance(t *testing.T) {
 	t.Run("Live block is not in store", func(t *testing.T) {
 		difference, headIndex, err := reconciler.CompareBalance(
 			ctx,
-			&AccountAndCurrency{
+			&storage.BalanceChange{
 				Account:  account1,
 				Currency: currency1,
 			},
@@ -404,7 +404,7 @@ func TestCompareBalance(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = blockStorage.UpdateBalance(ctx, txn, account1, amount1, block1)
+	_, err = blockStorage.UpdateBalance(ctx, txn, account1, amount1, block1)
 	assert.NoError(t, err)
 	err = txn.Commit(ctx)
 	assert.NoError(t, err)
@@ -412,7 +412,7 @@ func TestCompareBalance(t *testing.T) {
 	t.Run("Account updated after live block", func(t *testing.T) {
 		difference, headIndex, err := reconciler.CompareBalance(
 			ctx,
-			&AccountAndCurrency{
+			&storage.BalanceChange{
 				Account:  account1,
 				Currency: currency1,
 			},
@@ -427,7 +427,7 @@ func TestCompareBalance(t *testing.T) {
 	t.Run("Account balance matches", func(t *testing.T) {
 		difference, headIndex, err := reconciler.CompareBalance(
 			ctx,
-			&AccountAndCurrency{
+			&storage.BalanceChange{
 				Account:  account1,
 				Currency: currency1,
 			},
@@ -442,7 +442,7 @@ func TestCompareBalance(t *testing.T) {
 	t.Run("Account balance matches later live block", func(t *testing.T) {
 		difference, headIndex, err := reconciler.CompareBalance(
 			ctx,
-			&AccountAndCurrency{
+			&storage.BalanceChange{
 				Account:  account1,
 				Currency: currency1,
 			},
@@ -457,7 +457,7 @@ func TestCompareBalance(t *testing.T) {
 	t.Run("Balances are not equal", func(t *testing.T) {
 		difference, headIndex, err := reconciler.CompareBalance(
 			ctx,
-			&AccountAndCurrency{
+			&storage.BalanceChange{
 				Account:  account1,
 				Currency: currency1,
 			},
@@ -472,7 +472,7 @@ func TestCompareBalance(t *testing.T) {
 	t.Run("Compare balance for non-existent account", func(t *testing.T) {
 		difference, headIndex, err := reconciler.CompareBalance(
 			ctx,
-			&AccountAndCurrency{
+			&storage.BalanceChange{
 				Account:  account2,
 				Currency: currency1,
 			},

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -314,7 +314,7 @@ func TestCompareBalance(t *testing.T) {
 	defer database.Close(ctx)
 
 	blockStorage := storage.NewBlockStorage(ctx, database)
-	logger := logger.NewLogger(*newDir, false, false)
+	logger := logger.NewLogger(*newDir, false, false, false)
 	reconciler := New(ctx, nil, blockStorage, nil, logger, 1)
 
 	t.Run("No head block yet", func(t *testing.T) {
@@ -404,7 +404,7 @@ func TestCompareBalance(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, err = blockStorage.UpdateBalance(ctx, txn, account1, amount1, block1)
+	_, err = blockStorage.UpdateBalance(ctx, txn, account1, amount1, block1, nil)
 	assert.NoError(t, err)
 	err = txn.Commit(ctx)
 	assert.NoError(t, err)

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -314,7 +314,7 @@ func TestCompareBalance(t *testing.T) {
 	defer database.Close(ctx)
 
 	blockStorage := storage.NewBlockStorage(ctx, database)
-	logger := logger.NewLogger(*newDir, false, false, false)
+	logger := logger.NewLogger(*newDir, false, false, false, false)
 	reconciler := New(ctx, nil, blockStorage, nil, logger, 1)
 
 	t.Run("No head block yet", func(t *testing.T) {

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -37,13 +37,13 @@ func TestContainsAccountAndCurrency(t *testing.T) {
 		Decimals: 2,
 	}
 	accts := []*storage.BalanceChange{
-		&storage.BalanceChange{
+		{
 			Account: &rosetta.AccountIdentifier{
 				Address: "test",
 			},
 			Currency: currency1,
 		},
-		&storage.BalanceChange{
+		{
 			Account: &rosetta.AccountIdentifier{
 				Address: "cool",
 				SubAccount: &rosetta.SubAccountIdentifier{
@@ -52,7 +52,7 @@ func TestContainsAccountAndCurrency(t *testing.T) {
 			},
 			Currency: currency1,
 		},
-		&storage.BalanceChange{
+		{
 			Account: &rosetta.AccountIdentifier{
 				Address: "cool",
 				SubAccount: &rosetta.SubAccountIdentifier{
@@ -193,13 +193,13 @@ func TestExtractAmount(t *testing.T) {
 		}
 
 		balances = []*rosetta.Balance{
-			&rosetta.Balance{
+			{
 				AccountIdentifier: account1,
 				Amounts: []*rosetta.Amount{
 					amount1,
 				},
 			},
-			&rosetta.Balance{
+			{
 				AccountIdentifier: account2,
 				Amounts: []*rosetta.Amount{
 					amount2,

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -341,6 +341,10 @@ func (b *BlockStorage) RemoveBlock(
 ) error {
 	// Remove all transaction hashes
 	blockData, err := b.GetBlock(ctx, transaction, block)
+	if err != nil {
+		return err
+	}
+
 	for _, txn := range blockData.Transactions {
 		err = transaction.Delete(ctx, getHashKey(txn.TransactionIdentifier.Hash, false))
 		if err != nil {
@@ -607,7 +611,7 @@ func (b *BlockStorage) BootstrapBalances(
 
 		// Assert header is correct
 		if rowsRead == 1 {
-			if bootstrapBalancesHeader != strings.Join(record[:], ",") {
+			if bootstrapBalancesHeader != strings.Join(record, ",") {
 				return ErrIncorrectHeader
 			}
 

--- a/internal/storage/block_storage.go
+++ b/internal/storage/block_storage.go
@@ -413,9 +413,10 @@ func GetCurrencyKey(currency *rosetta.Currency) string {
 type BalanceChange struct {
 	Account    *rosetta.AccountIdentifier
 	Currency   *rosetta.Currency
-	Block      *rosetta.BlockIdentifier
-	OldValue   string
+	NewBlock   *rosetta.BlockIdentifier
 	NewValue   string
+	OldBlock   *rosetta.BlockIdentifier
+	OldValue   string
 	Difference string
 }
 
@@ -475,7 +476,8 @@ func (b *BlockStorage) UpdateBalance(
 		return &BalanceChange{
 			Account:    account,
 			Currency:   amount.Currency,
-			Block:      block,
+			OldBlock:   nil,
+			NewBlock:   block,
 			OldValue:   "0",
 			NewValue:   amount.Value,
 			Difference: amount.Value,
@@ -517,6 +519,7 @@ func (b *BlockStorage) UpdateBalance(
 
 	parseBal.Amounts[currencyKey] = val
 
+	oldBlock := parseBal.Block
 	parseBal.Block = block
 	serialBal, err := serializeBalanceEntry(*parseBal)
 	if err != nil {
@@ -530,9 +533,10 @@ func (b *BlockStorage) UpdateBalance(
 	return &BalanceChange{
 		Account:    account,
 		Currency:   amount.Currency,
-		Block:      block,
-		OldValue:   existing.String(),
+		NewBlock:   block,
 		NewValue:   newVal.String(),
+		OldBlock:   oldBlock,
+		OldValue:   existing.String(),
 		Difference: amount.Value,
 	}, nil
 }

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -399,13 +399,14 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Set and get balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		assert.NoError(t, storage.UpdateBalance(
+		_, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account,
 			amount,
 			newBlock,
-		))
+		)
+		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
 		txn = storage.NewDatabaseTransaction(ctx, false)
@@ -418,13 +419,15 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Set balance with nil currency", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		assert.EqualError(t, storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account,
 			amountNilCurrency,
 			newBlock,
-		), "invalid amount")
+		)
+		assert.Nil(t, balanceChange)
+		assert.EqualError(t, err, "invalid amount")
 		txn.Discard(ctx)
 
 		txn = storage.NewDatabaseTransaction(ctx, false)
@@ -437,13 +440,14 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Modify existing balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		assert.NoError(t, storage.UpdateBalance(
+		_, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account,
 			amount,
 			newBlock2,
-		))
+		)
+		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
 		txn = storage.NewDatabaseTransaction(ctx, true)
@@ -456,13 +460,14 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Discard transaction", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		assert.NoError(t, storage.UpdateBalance(
+		_, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account,
 			amount,
 			newBlock3,
-		))
+		)
+		assert.NoError(t, err)
 
 		// Get balance during transaction
 		txn2 := storage.NewDatabaseTransaction(ctx, false)
@@ -484,39 +489,42 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Attempt modification to push balance negative on existing account", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		err = storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account,
 			largeDeduction,
 			newBlock2,
 		)
+		assert.Nil(t, balanceChange)
 		assert.Contains(t, err.Error(), ErrNegativeBalance.Error())
 		txn.Discard(ctx)
 	})
 
 	t.Run("Attempt modification to push balance negative on new acct", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		err = storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account2,
 			largeDeduction,
 			newBlock2,
 		)
+		assert.Nil(t, balanceChange)
 		assert.Contains(t, err.Error(), ErrNegativeBalance.Error())
 		txn.Discard(ctx)
 	})
 
 	t.Run("sub account set and get balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		assert.NoError(t, storage.UpdateBalance(
+		_, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			subAccount,
 			amount,
 			newBlock,
-		))
+		)
+		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
 		txn = storage.NewDatabaseTransaction(ctx, false)
@@ -529,13 +537,14 @@ func TestBalance(t *testing.T) {
 
 	t.Run("sub account metadata set and get balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		assert.NoError(t, storage.UpdateBalance(
+		_, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			subAccountMetadata,
 			amount,
 			newBlock,
-		))
+		)
+		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
 		txn = storage.NewDatabaseTransaction(ctx, false)
@@ -548,13 +557,14 @@ func TestBalance(t *testing.T) {
 
 	t.Run("sub account unique metadata set and get balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		assert.NoError(t, storage.UpdateBalance(
+		_, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			subAccountMetadata2,
 			amount,
 			newBlock,
-		))
+		)
+		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
 		txn = storage.NewDatabaseTransaction(ctx, false)

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -356,9 +356,15 @@ func TestBalance(t *testing.T) {
 			Hash:  "kdasdj",
 			Index: 123890,
 		}
+		newTransaction = &rosetta.TransactionIdentifier{
+			Hash: "tx1",
+		}
 		newBlock2 = &rosetta.BlockIdentifier{
 			Hash:  "pkdasdj",
 			Index: 123890,
+		}
+		newTransaction2 = &rosetta.TransactionIdentifier{
+			Hash: "tx2",
 		}
 		result = map[string]*rosetta.Amount{
 			GetCurrencyKey(currency): &rosetta.Amount{
@@ -399,14 +405,25 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Set and get balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		_, err := storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account,
 			amount,
 			newBlock,
-			nil,
+			newTransaction,
 		)
+		assert.Equal(t, &BalanceChange{
+			Account: &rosetta.AccountIdentifier{
+				Address: "blah",
+			},
+			Currency:    currency,
+			Block:       newBlock,
+			Transaction: newTransaction,
+			OldValue:    "0",
+			NewValue:    "100",
+			Difference:  "100",
+		}, balanceChange)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
@@ -442,14 +459,26 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Modify existing balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		_, err := storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account,
 			amount,
 			newBlock2,
-			nil,
+			newTransaction2,
 		)
+		assert.Equal(t, &BalanceChange{
+			Account: &rosetta.AccountIdentifier{
+				Address: "blah",
+			},
+			Currency:    currency,
+			Block:       newBlock2,
+			OldBlock:    newBlock,
+			Transaction: newTransaction2,
+			OldValue:    "100",
+			NewValue:    "200",
+			Difference:  "100",
+		}, balanceChange)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
@@ -463,7 +492,7 @@ func TestBalance(t *testing.T) {
 
 	t.Run("Discard transaction", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		_, err := storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			account,
@@ -471,6 +500,17 @@ func TestBalance(t *testing.T) {
 			newBlock3,
 			nil,
 		)
+		assert.Equal(t, &BalanceChange{
+			Account: &rosetta.AccountIdentifier{
+				Address: "blah",
+			},
+			Currency:   currency,
+			Block:      newBlock3,
+			OldBlock:   newBlock2,
+			OldValue:   "200",
+			NewValue:   "300",
+			Difference: "100",
+		}, balanceChange)
 		assert.NoError(t, err)
 
 		// Get balance during transaction
@@ -523,14 +563,23 @@ func TestBalance(t *testing.T) {
 
 	t.Run("sub account set and get balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		_, err := storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			subAccount,
 			amount,
 			newBlock,
-			nil,
+			newTransaction,
 		)
+		assert.Equal(t, &BalanceChange{
+			Account:     subAccount,
+			Currency:    currency,
+			Block:       newBlock,
+			Transaction: newTransaction,
+			OldValue:    "0",
+			NewValue:    "100",
+			Difference:  "100",
+		}, balanceChange)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
@@ -544,14 +593,23 @@ func TestBalance(t *testing.T) {
 
 	t.Run("sub account metadata set and get balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		_, err := storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			subAccountMetadata,
 			amount,
 			newBlock,
-			nil,
+			newTransaction,
 		)
+		assert.Equal(t, &BalanceChange{
+			Account:     subAccountMetadata,
+			Currency:    currency,
+			Block:       newBlock,
+			Transaction: newTransaction,
+			OldValue:    "0",
+			NewValue:    "100",
+			Difference:  "100",
+		}, balanceChange)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 
@@ -565,14 +623,23 @@ func TestBalance(t *testing.T) {
 
 	t.Run("sub account unique metadata set and get balance", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
-		_, err := storage.UpdateBalance(
+		balanceChange, err := storage.UpdateBalance(
 			ctx,
 			txn,
 			subAccountMetadata2,
 			amount,
 			newBlock,
-			nil,
+			newTransaction,
 		)
+		assert.Equal(t, &BalanceChange{
+			Account:     subAccountMetadata2,
+			Currency:    currency,
+			Block:       newBlock,
+			Transaction: newTransaction,
+			OldValue:    "0",
+			NewValue:    "100",
+			Difference:  "100",
+		}, balanceChange)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
 

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -109,12 +109,12 @@ func TestBlock(t *testing.T) {
 			},
 			Timestamp: 1,
 			Transactions: []*rosetta.Transaction{
-				&rosetta.Transaction{
+				{
 					TransactionIdentifier: &rosetta.TransactionIdentifier{
 						Hash: "blahTx",
 					},
 					Operations: []*rosetta.Operation{
-						&rosetta.Operation{
+						{
 							OperationIdentifier: &rosetta.OperationIdentifier{
 								Index: 0,
 							},
@@ -136,12 +136,12 @@ func TestBlock(t *testing.T) {
 			},
 			Timestamp: 1,
 			Transactions: []*rosetta.Transaction{
-				&rosetta.Transaction{
+				{
 					TransactionIdentifier: &rosetta.TransactionIdentifier{
 						Hash: "blahTx",
 					},
 					Operations: []*rosetta.Operation{
-						&rosetta.Operation{
+						{
 							OperationIdentifier: &rosetta.OperationIdentifier{
 								Index: 0,
 							},
@@ -179,7 +179,11 @@ func TestBlock(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, false)
 		block, err := storage.GetBlock(ctx, txn, badBlockIdentifier)
 		txn.Discard(ctx)
-		assert.EqualError(t, err, fmt.Errorf("%w %+v", ErrBlockNotFound, badBlockIdentifier).Error())
+		assert.EqualError(
+			t,
+			err,
+			fmt.Errorf("%w %+v", ErrBlockNotFound, badBlockIdentifier).Error(),
+		)
 		assert.Nil(t, block)
 	})
 
@@ -367,7 +371,7 @@ func TestBalance(t *testing.T) {
 			Hash: "tx2",
 		}
 		result = map[string]*rosetta.Amount{
-			GetCurrencyKey(currency): &rosetta.Amount{
+			GetCurrencyKey(currency): {
 				Value:    "200",
 				Currency: currency,
 			},
@@ -750,8 +754,8 @@ func TestBootstrapBalances(t *testing.T) {
 
 	t.Run("Set balance successfully", func(t *testing.T) {
 		f, err := createBootstrapBalancesFile(*newDir)
-		defer f.Close()
 		assert.NoError(t, err)
+		defer f.Close()
 
 		_, err = f.WriteString(fmt.Sprintf(
 			"%s\n",
@@ -798,8 +802,8 @@ func TestBootstrapBalances(t *testing.T) {
 
 	t.Run("Invalid file header", func(t *testing.T) {
 		f, err := createBootstrapBalancesFile(*newDir)
-		defer f.Close()
 		assert.NoError(t, err)
+		defer f.Close()
 
 		_, err = f.WriteString("bad header")
 		assert.NoError(t, err)
@@ -814,8 +818,8 @@ func TestBootstrapBalances(t *testing.T) {
 
 	t.Run("Invalid account row", func(t *testing.T) {
 		f, err := createBootstrapBalancesFile(*newDir)
-		defer f.Close()
 		assert.NoError(t, err)
+		defer f.Close()
 
 		_, err = f.WriteString(fmt.Sprintf(
 			"%s\n",
@@ -836,8 +840,8 @@ func TestBootstrapBalances(t *testing.T) {
 
 	t.Run("Invalid account value", func(t *testing.T) {
 		f, err := createBootstrapBalancesFile(*newDir)
-		defer f.Close()
 		assert.NoError(t, err)
+		defer f.Close()
 
 		_, err = f.WriteString(fmt.Sprintf(
 			"%s\n",

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -405,6 +405,7 @@ func TestBalance(t *testing.T) {
 			account,
 			amount,
 			newBlock,
+			nil,
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
@@ -425,6 +426,7 @@ func TestBalance(t *testing.T) {
 			account,
 			amountNilCurrency,
 			newBlock,
+			nil,
 		)
 		assert.Nil(t, balanceChange)
 		assert.EqualError(t, err, "invalid amount")
@@ -446,6 +448,7 @@ func TestBalance(t *testing.T) {
 			account,
 			amount,
 			newBlock2,
+			nil,
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
@@ -466,6 +469,7 @@ func TestBalance(t *testing.T) {
 			account,
 			amount,
 			newBlock3,
+			nil,
 		)
 		assert.NoError(t, err)
 
@@ -495,6 +499,7 @@ func TestBalance(t *testing.T) {
 			account,
 			largeDeduction,
 			newBlock2,
+			nil,
 		)
 		assert.Nil(t, balanceChange)
 		assert.Contains(t, err.Error(), ErrNegativeBalance.Error())
@@ -509,6 +514,7 @@ func TestBalance(t *testing.T) {
 			account2,
 			largeDeduction,
 			newBlock2,
+			nil,
 		)
 		assert.Nil(t, balanceChange)
 		assert.Contains(t, err.Error(), ErrNegativeBalance.Error())
@@ -523,6 +529,7 @@ func TestBalance(t *testing.T) {
 			subAccount,
 			amount,
 			newBlock,
+			nil,
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
@@ -543,6 +550,7 @@ func TestBalance(t *testing.T) {
 			subAccountMetadata,
 			amount,
 			newBlock,
+			nil,
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))
@@ -563,6 +571,7 @@ func TestBalance(t *testing.T) {
 			subAccountMetadata2,
 			amount,
 			newBlock,
+			nil,
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, txn.Commit(ctx))

--- a/internal/storage/utils.go
+++ b/internal/storage/utils.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 )
 
@@ -32,6 +33,8 @@ func CreateTempDir() (*string, error) {
 
 // RemoveTempDir deletes a directory at
 // a provided path for usage within testing.
-func RemoveTempDir(dir string) error {
-	return os.RemoveAll(dir)
+func RemoveTempDir(dir string) {
+	if err := os.RemoveAll(dir); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -346,12 +346,13 @@ func (s *Syncer) nextSyncableRange(
 
 	var startIndex int64
 	head, err := s.storage.GetHeadBlockIdentifier(ctx, tx)
-	if err == nil {
+	switch err {
+	case nil:
 		startIndex = head.Index + 1
-	} else if err == storage.ErrHeadBlockNotFound {
+	case storage.ErrHeadBlockNotFound:
 		head = genesisBlockIdentifier
 		startIndex = head.Index
-	} else {
+	default:
 		return -1, -1, -1, err
 	}
 

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -104,7 +104,7 @@ var (
 	}
 
 	blockSequenceNoReorg = []*rosetta.Block{
-		&rosetta.Block{ // genesis
+		{ // genesis
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
@@ -114,7 +114,7 @@ var (
 				Index: 0,
 			},
 		},
-		&rosetta.Block{
+		{
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "1",
 				Index: 1,
@@ -124,7 +124,7 @@ var (
 				Index: 0,
 			},
 		},
-		&rosetta.Block{
+		{
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "2",
 				Index: 2,
@@ -137,7 +137,7 @@ var (
 				recipientTransaction,
 			},
 		},
-		&rosetta.Block{
+		{
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "3",
 				Index: 3,
@@ -165,7 +165,7 @@ var (
 	}
 
 	blockSequenceReorg = []*rosetta.Block{
-		&rosetta.Block{ // genesis
+		{ // genesis
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
@@ -175,7 +175,7 @@ var (
 				Index: 0,
 			},
 		},
-		&rosetta.Block{
+		{
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "1",
 				Index: 1,
@@ -188,7 +188,7 @@ var (
 				recipientTransaction,
 			},
 		},
-		&rosetta.Block{
+		{
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "2",
 				Index: 2,
@@ -198,7 +198,7 @@ var (
 				Index: 1,
 			},
 		},
-		&rosetta.Block{
+		{
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "1a",
 				Index: 1,
@@ -208,7 +208,7 @@ var (
 				Index: 0,
 			},
 		},
-		&rosetta.Block{
+		{
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "3",
 				Index: 3,
@@ -218,7 +218,7 @@ var (
 				Index: 2,
 			},
 		},
-		&rosetta.Block{ // invalid block
+		{ // invalid block
 			BlockIdentifier: &rosetta.BlockIdentifier{
 				Hash:  "5",
 				Index: 5,
@@ -231,11 +231,11 @@ var (
 	}
 
 	operationStatuses = []*rosetta.OperationStatus{
-		&rosetta.OperationStatus{
+		{
 			Status:     "Success",
 			Successful: true,
 		},
-		&rosetta.OperationStatus{
+		{
 			Status:     "Failure",
 			Successful: false,
 		},
@@ -327,7 +327,7 @@ func TestNoReorgProcessBlock(t *testing.T) {
 		currIndex = newIndex
 		assert.Equal(t, int64(3), currIndex)
 		assert.Equal(t, []*storage.BalanceChange{
-			&storage.BalanceChange{
+			{
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
@@ -479,7 +479,7 @@ func TestReorgProcessBlock(t *testing.T) {
 		currIndex = newIndex
 		assert.Equal(t, int64(2), currIndex)
 		assert.Equal(t, []*storage.BalanceChange{
-			&storage.BalanceChange{
+			{
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
@@ -520,7 +520,7 @@ func TestReorgProcessBlock(t *testing.T) {
 		currIndex = newIndex
 		assert.Equal(t, int64(1), currIndex)
 		assert.Equal(t, []*storage.BalanceChange{
-			&storage.BalanceChange{
+			{
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
@@ -545,7 +545,7 @@ func TestReorgProcessBlock(t *testing.T) {
 		// Assert that balance change was reverted
 		// only by the successful operation
 		zeroAmount := map[string]*rosetta.Amount{
-			storage.GetCurrencyKey(currency): &rosetta.Amount{
+			storage.GetCurrencyKey(currency): {
 				Value:    "0",
 				Currency: currency,
 			},

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -270,7 +270,7 @@ func TestNoReorgProcessBlock(t *testing.T) {
 	defer database.Close(ctx)
 
 	blockStorage := storage.NewBlockStorage(ctx, database)
-	logger := logger.NewLogger(*newDir, false, false, false)
+	logger := logger.NewLogger(*newDir, false, false, false, false)
 	fetcher := &fetcher.Fetcher{
 		Asserter: asserter.New(ctx, networkStatusResponse),
 	}
@@ -417,7 +417,7 @@ func TestReorgProcessBlock(t *testing.T) {
 	defer database.Close(ctx)
 
 	blockStorage := storage.NewBlockStorage(ctx, database)
-	logger := logger.NewLogger(*newDir, false, false, false)
+	logger := logger.NewLogger(*newDir, false, false, false, false)
 	fetcher := &fetcher.Fetcher{
 		Asserter: asserter.New(ctx, networkStatusResponse),
 	}

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -270,7 +270,7 @@ func TestNoReorgProcessBlock(t *testing.T) {
 	defer database.Close(ctx)
 
 	blockStorage := storage.NewBlockStorage(ctx, database)
-	logger := logger.NewLogger(*newDir, false, false)
+	logger := logger.NewLogger(*newDir, false, false, false)
 	fetcher := &fetcher.Fetcher{
 		Asserter: asserter.New(ctx, networkStatusResponse),
 	}
@@ -331,11 +331,12 @@ func TestNoReorgProcessBlock(t *testing.T) {
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
-				Currency:   currency,
-				NewBlock:   blockSequenceNoReorg[2].BlockIdentifier,
-				OldValue:   "0",
-				NewValue:   "100",
-				Difference: "100",
+				Currency:    currency,
+				Block:       blockSequenceNoReorg[2].BlockIdentifier,
+				Transaction: blockSequenceNoReorg[2].Transactions[0].TransactionIdentifier,
+				OldValue:    "0",
+				NewValue:    "100",
+				Difference:  "100",
 			},
 		}, balanceChanges)
 		assert.NoError(t, err)
@@ -416,7 +417,7 @@ func TestReorgProcessBlock(t *testing.T) {
 	defer database.Close(ctx)
 
 	blockStorage := storage.NewBlockStorage(ctx, database)
-	logger := logger.NewLogger(*newDir, false, false)
+	logger := logger.NewLogger(*newDir, false, false, false)
 	fetcher := &fetcher.Fetcher{
 		Asserter: asserter.New(ctx, networkStatusResponse),
 	}
@@ -482,11 +483,12 @@ func TestReorgProcessBlock(t *testing.T) {
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
-				Currency:   currency,
-				NewBlock:   blockSequenceReorg[1].BlockIdentifier,
-				OldValue:   "0",
-				NewValue:   "100",
-				Difference: "100",
+				Currency:    currency,
+				Block:       blockSequenceReorg[1].BlockIdentifier,
+				Transaction: blockSequenceReorg[1].Transactions[0].TransactionIdentifier,
+				OldValue:    "0",
+				NewValue:    "100",
+				Difference:  "100",
 			},
 		}, balanceChanges)
 		assert.NoError(t, err)
@@ -522,12 +524,13 @@ func TestReorgProcessBlock(t *testing.T) {
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
-				Currency:   currency,
-				NewBlock:   blockSequenceReorg[0].BlockIdentifier,
-				OldBlock:   blockSequenceReorg[1].BlockIdentifier,
-				OldValue:   "100",
-				NewValue:   "0",
-				Difference: "-100",
+				Currency:    currency,
+				Block:       blockSequenceReorg[0].BlockIdentifier,
+				Transaction: blockSequenceReorg[1].Transactions[0].TransactionIdentifier,
+				OldBlock:    blockSequenceReorg[1].BlockIdentifier,
+				OldValue:    "100",
+				NewValue:    "0",
+				Difference:  "-100",
 			},
 		}, balanceChanges)
 		assert.NoError(t, err)

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -331,7 +331,11 @@ func TestNoReorgProcessBlock(t *testing.T) {
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
-				Currency: currency,
+				Currency:   currency,
+				NewBlock:   blockSequenceNoReorg[2].BlockIdentifier,
+				OldValue:   "0",
+				NewValue:   "100",
+				Difference: "100",
 			},
 		}, balanceChanges)
 		assert.NoError(t, err)
@@ -478,7 +482,11 @@ func TestReorgProcessBlock(t *testing.T) {
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
-				Currency: currency,
+				Currency:   currency,
+				NewBlock:   blockSequenceReorg[1].BlockIdentifier,
+				OldValue:   "0",
+				NewValue:   "100",
+				Difference: "100",
 			},
 		}, balanceChanges)
 		assert.NoError(t, err)
@@ -514,7 +522,12 @@ func TestReorgProcessBlock(t *testing.T) {
 				Account: &rosetta.AccountIdentifier{
 					Address: "acct1",
 				},
-				Currency: currency,
+				Currency:   currency,
+				NewBlock:   blockSequenceReorg[0].BlockIdentifier,
+				OldBlock:   blockSequenceReorg[1].BlockIdentifier,
+				OldValue:   "100",
+				NewValue:   "0",
+				Difference: "-100",
 			},
 		}, balanceChanges)
 		assert.NoError(t, err)

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ type config struct {
 	LogTransactions        bool   `env:"LOG_TRANSACTIONS,required"`
 	LogBenchmarks          bool   `env:"LOG_BENCHMARKS,required"`
 	LogBalances            bool   `env:"LOG_BALANCES,required"`
+	LogReconciliation      bool   `env:"LOG_RECONCILIATION,required"`
 	BootstrapBalances      bool   `env:"BOOTSTRAP_BALANCES,required"`
 }
 
@@ -100,6 +101,7 @@ func main() {
 		cfg.LogTransactions,
 		cfg.LogBenchmarks,
 		cfg.LogBalances,
+		cfg.LogReconciliation,
 	)
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ type config struct {
 	AccountConcurrency     int    `env:"ACCOUNT_CONCURRENCY,required"`
 	LogTransactions        bool   `env:"LOG_TRANSACTIONS,required"`
 	LogBenchmarks          bool   `env:"LOG_BENCHMARKS,required"`
+	LogBalances            bool   `env:"LOG_BALANCES,required"`
 	BootstrapBalances      bool   `env:"BOOTSTRAP_BALANCES,required"`
 }
 
@@ -90,7 +91,12 @@ func main() {
 		}
 	}
 
-	logger := logger.NewLogger(cfg.DataDir, cfg.LogTransactions, cfg.LogBenchmarks)
+	logger := logger.NewLogger(
+		cfg.DataDir,
+		cfg.LogTransactions,
+		cfg.LogBenchmarks,
+		cfg.LogBalances,
+	)
 
 	g, ctx := errgroup.WithContext(ctx)
 

--- a/main.go
+++ b/main.go
@@ -44,6 +44,10 @@ type config struct {
 	BootstrapBalances      bool   `env:"BOOTSTRAP_BALANCES,required"`
 }
 
+const (
+	defaultHTTPTimeout = 10 * time.Second
+)
+
 func main() {
 	ctx := context.Background()
 
@@ -57,7 +61,7 @@ func main() {
 		cfg.ServerURL,
 		"rosetta-validator",
 		&http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: defaultHTTPTimeout,
 		},
 		cfg.BlockConcurrency,
 		cfg.TransactionConcurrency,


### PR DESCRIPTION
### Motivation
When there is a reconciliation error, it is really tough to debug. There is no way to look at the previously computed balances changes for a particular account or previous reconciliations (comparing computed balance to live balance on the node).

### Solution
Log all balances changes to `balances.txt` and reconciliations to `reconciliations.txt` (if configured in the `Makefile`).

### Future Work
This is a first pass to provide rudimentary support and will be improved later to make querying much easier (potentially with a SQL datastore).