### PR TITLE
1.3.1 Specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ LOG_BENCHMARKS?=false
 LOG_BALANCES?=true
 LOG_RECONCILIATION?=true
 BOOTSTRAP_BALANCES?=false
+RECONCILE_BALANCES?=true
 
 deps:
 	go get ./...
@@ -65,6 +66,7 @@ validate:
 		-e LOG_BALANCES="${LOG_BALANCES}" \
 		-e LOG_RECONCILIATION="${LOG_RECONCILIATION}" \
 		-e BOOTSTRAP_BALANCES="${BOOTSTRAP_BALANCES}" \
+		-e RECONCILE_BALANCES="${RECONCILE_BALANCES}" \
 		--network host \
 		rosetta-validator \
 		rosetta-validator;

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ _Default: http://localhost:8080_
 
 The URL the validator will use to access the Rosetta Server.
 
+#### RECONCILE_BALANCES
+_Default: true_
+
+Computed balances will be reconciled against balances returned by the node.
+
 #### LOG_TRANSACTIONS
 _Default: true_
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/caarlos0/env v3.5.0+incompatible
-	github.com/coinbase/rosetta-sdk-go v0.1.3
+	github.com/coinbase/rosetta-sdk-go v0.1.4
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger v1.6.0
 	github.com/stretchr/testify v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/caarlos0/env v3.5.0+incompatible
-	github.com/coinbase/rosetta-sdk-go v0.0.3
+	github.com/coinbase/rosetta-sdk-go v0.1.3
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger v1.6.0
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,12 @@ github.com/coinbase/rosetta-sdk-go v0.0.1 h1:s6oBsnXCEmTvZxNTHZ4+sjSSWEGCtCBO7kT
 github.com/coinbase/rosetta-sdk-go v0.0.1/go.mod h1:T7kbh9AOzlxEITJGt2Fu854vxg/yEjy5MsR1woSM5aI=
 github.com/coinbase/rosetta-sdk-go v0.0.3 h1:raFtDs4u0P7h7H+HzHpGQzDYctEpL80nx3e/EY4esXk=
 github.com/coinbase/rosetta-sdk-go v0.0.3/go.mod h1:T7kbh9AOzlxEITJGt2Fu854vxg/yEjy5MsR1woSM5aI=
+github.com/coinbase/rosetta-sdk-go v0.1.1 h1:nn0YQOAhOxbK16X+6vSoo9Xb7iRGki9Y88Y7i35d5+w=
+github.com/coinbase/rosetta-sdk-go v0.1.1/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
+github.com/coinbase/rosetta-sdk-go v0.1.2 h1:N5i37O/+6sMO1vd7mfWtDO7Pm16d9KO+qg7x4nhDWOs=
+github.com/coinbase/rosetta-sdk-go v0.1.2/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
+github.com/coinbase/rosetta-sdk-go v0.1.3 h1:ksyrtwHBZUwU/T6FVKCH6769QdQPwJrBY05tfC7X+gY=
+github.com/coinbase/rosetta-sdk-go v0.1.3/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -26,6 +32,7 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/coinbase/rosetta-sdk-go v0.1.2 h1:N5i37O/+6sMO1vd7mfWtDO7Pm16d9KO+qg7
 github.com/coinbase/rosetta-sdk-go v0.1.2/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
 github.com/coinbase/rosetta-sdk-go v0.1.3 h1:ksyrtwHBZUwU/T6FVKCH6769QdQPwJrBY05tfC7X+gY=
 github.com/coinbase/rosetta-sdk-go v0.1.3/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
+github.com/coinbase/rosetta-sdk-go v0.1.4 h1:XGXuAk4xJkcSuXY325wCSSjiTkhp/zFcyXmAnveJ9Ks=
+github.com/coinbase/rosetta-sdk-go v0.1.4/go.mod h1:lbmGsBpBiSZWP4WQqEW2CuTweGcU/ioQHwZ8CYo6yO8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -24,7 +24,7 @@ import (
 	"github.com/coinbase/rosetta-validator/internal/storage"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
-	rosetta "github.com/coinbase/rosetta-sdk-go/gen"
+	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
 const (
@@ -104,7 +104,7 @@ func NewLogger(
 // blockStreamFile output file.
 func (l *Logger) BlockStream(
 	ctx context.Context,
-	block *rosetta.Block,
+	block *types.Block,
 	orphan bool,
 ) error {
 	f, err := os.OpenFile(
@@ -141,7 +141,7 @@ func (l *Logger) BlockStream(
 // to the end of the transactionStreamFile.
 func (l *Logger) TransactionStream(
 	ctx context.Context,
-	block *rosetta.Block,
+	block *types.Block,
 	verb string,
 ) error {
 	if !l.logTransactions {
@@ -268,10 +268,10 @@ func (l *Logger) BalanceStream(
 // during syncing.
 func (l *Logger) ReconcileStream(
 	ctx context.Context,
-	account *rosetta.AccountIdentifier,
-	currency *rosetta.Currency,
-	liveBalance *rosetta.Amount,
-	liveBlock *rosetta.BlockIdentifier,
+	account *types.AccountIdentifier,
+	currency *types.Currency,
+	liveBalance *types.Amount,
+	liveBlock *types.BlockIdentifier,
 ) error {
 	if !l.logReconciliation {
 		return nil
@@ -377,7 +377,7 @@ func (l *Logger) BlockLatency(
 // account fetch benchmarks to the account_benchmarks.csv file.
 func (l *Logger) AccountLatency(
 	ctx context.Context,
-	account *rosetta.AccountIdentifier,
+	account *types.AccountIdentifier,
 	latency float64,
 	balances int,
 ) error {
@@ -404,7 +404,7 @@ func (l *Logger) AccountLatency(
 
 	addressString := account.Address
 	if account.SubAccount != nil {
-		addressString += account.SubAccount.SubAccount
+		addressString += account.SubAccount.Address
 	}
 
 	_, err = f.WriteString(fmt.Sprintf(
@@ -417,10 +417,10 @@ func (l *Logger) AccountLatency(
 	return err
 }
 
-// Network pretty prints the rosetta.NetworkStatusResponse to the console.
+// Network pretty prints the types.NetworkStatusResponse to the console.
 func Network(
 	ctx context.Context,
-	network *rosetta.NetworkStatusResponse,
+	network *types.NetworkStatusResponse,
 ) error {
 	b, err := json.MarshalIndent(network, "", " ")
 	if err != nil {

--- a/internal/storage/block_storage_test.go
+++ b/internal/storage/block_storage_test.go
@@ -21,18 +21,18 @@ import (
 	"path"
 	"testing"
 
-	rosetta "github.com/coinbase/rosetta-sdk-go/gen"
+	"github.com/coinbase/rosetta-sdk-go/types"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestHeadBlockIdentifier(t *testing.T) {
 	var (
-		newBlockIdentifier = &rosetta.BlockIdentifier{
+		newBlockIdentifier = &types.BlockIdentifier{
 			Hash:  "blah",
 			Index: 0,
 		}
-		newBlockIdentifier2 = &rosetta.BlockIdentifier{
+		newBlockIdentifier2 = &types.BlockIdentifier{
 			Hash:  "blah2",
 			Index: 1,
 		}
@@ -73,7 +73,7 @@ func TestHeadBlockIdentifier(t *testing.T) {
 	t.Run("Discard head block update", func(t *testing.T) {
 		txn := storage.NewDatabaseTransaction(ctx, true)
 		assert.NoError(t, storage.StoreHeadBlockIdentifier(ctx, txn,
-			&rosetta.BlockIdentifier{
+			&types.BlockIdentifier{
 				Hash:  "no blah",
 				Index: 10,
 			}),
@@ -102,20 +102,20 @@ func TestHeadBlockIdentifier(t *testing.T) {
 
 func TestBlock(t *testing.T) {
 	var (
-		newBlock = &rosetta.Block{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+		newBlock = &types.Block{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "blah",
 				Index: 0,
 			},
 			Timestamp: 1,
-			Transactions: []*rosetta.Transaction{
+			Transactions: []*types.Transaction{
 				{
-					TransactionIdentifier: &rosetta.TransactionIdentifier{
+					TransactionIdentifier: &types.TransactionIdentifier{
 						Hash: "blahTx",
 					},
-					Operations: []*rosetta.Operation{
+					Operations: []*types.Operation{
 						{
-							OperationIdentifier: &rosetta.OperationIdentifier{
+							OperationIdentifier: &types.OperationIdentifier{
 								Index: 0,
 							},
 						},
@@ -124,25 +124,25 @@ func TestBlock(t *testing.T) {
 			},
 		}
 
-		badBlockIdentifier = &rosetta.BlockIdentifier{
+		badBlockIdentifier = &types.BlockIdentifier{
 			Hash:  "missing blah",
 			Index: 0,
 		}
 
-		newBlock2 = &rosetta.Block{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+		newBlock2 = &types.Block{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "blah 2",
 				Index: 1,
 			},
 			Timestamp: 1,
-			Transactions: []*rosetta.Transaction{
+			Transactions: []*types.Transaction{
 				{
-					TransactionIdentifier: &rosetta.TransactionIdentifier{
+					TransactionIdentifier: &types.TransactionIdentifier{
 						Hash: "blahTx",
 					},
-					Operations: []*rosetta.Operation{
+					Operations: []*types.Operation{
 						{
-							OperationIdentifier: &rosetta.OperationIdentifier{
+							OperationIdentifier: &types.OperationIdentifier{
 								Index: 0,
 							},
 						},
@@ -222,29 +222,29 @@ func TestBlock(t *testing.T) {
 
 func TestGetBalanceKey(t *testing.T) {
 	var tests = map[string]struct {
-		account *rosetta.AccountIdentifier
+		account *types.AccountIdentifier
 		key     string
 	}{
 		"simple account": {
-			account: &rosetta.AccountIdentifier{
+			account: &types.AccountIdentifier{
 				Address: "hello",
 			},
 			key: "balance:hello",
 		},
 		"subaccount": {
-			account: &rosetta.AccountIdentifier{
+			account: &types.AccountIdentifier{
 				Address: "hello",
-				SubAccount: &rosetta.SubAccountIdentifier{
-					SubAccount: "stake",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "stake",
 				},
 			},
 			key: "balance:hello:stake",
 		},
 		"subaccount with string metadata": {
-			account: &rosetta.AccountIdentifier{
+			account: &types.AccountIdentifier{
 				Address: "hello",
-				SubAccount: &rosetta.SubAccountIdentifier{
-					SubAccount: "stake",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "stake",
 					Metadata: &map[string]interface{}{
 						"cool": "neat",
 					},
@@ -253,10 +253,10 @@ func TestGetBalanceKey(t *testing.T) {
 			key: "balance:hello:stake:map[cool:neat]",
 		},
 		"subaccount with number metadata": {
-			account: &rosetta.AccountIdentifier{
+			account: &types.AccountIdentifier{
 				Address: "hello",
-				SubAccount: &rosetta.SubAccountIdentifier{
-					SubAccount: "stake",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "stake",
 					Metadata: &map[string]interface{}{
 						"cool": 1,
 					},
@@ -265,10 +265,10 @@ func TestGetBalanceKey(t *testing.T) {
 			key: "balance:hello:stake:map[cool:1]",
 		},
 		"subaccount with complex metadata": {
-			account: &rosetta.AccountIdentifier{
+			account: &types.AccountIdentifier{
 				Address: "hello",
-				SubAccount: &rosetta.SubAccountIdentifier{
-					SubAccount: "stake",
+				SubAccount: &types.SubAccountIdentifier{
+					Address: "stake",
 					Metadata: &map[string]interface{}{
 						"cool":    1,
 						"awesome": "neat",
@@ -288,99 +288,99 @@ func TestGetBalanceKey(t *testing.T) {
 
 func TestBalance(t *testing.T) {
 	var (
-		account = &rosetta.AccountIdentifier{
+		account = &types.AccountIdentifier{
 			Address: "blah",
 		}
-		account2 = &rosetta.AccountIdentifier{
+		account2 = &types.AccountIdentifier{
 			Address: "blah2",
 		}
-		subAccount = &rosetta.AccountIdentifier{
+		subAccount = &types.AccountIdentifier{
 			Address: "blah",
-			SubAccount: &rosetta.SubAccountIdentifier{
-				SubAccount: "stake",
+			SubAccount: &types.SubAccountIdentifier{
+				Address: "stake",
 			},
 		}
-		subAccountNewPointer = &rosetta.AccountIdentifier{
+		subAccountNewPointer = &types.AccountIdentifier{
 			Address: "blah",
-			SubAccount: &rosetta.SubAccountIdentifier{
-				SubAccount: "stake",
+			SubAccount: &types.SubAccountIdentifier{
+				Address: "stake",
 			},
 		}
-		subAccountMetadata = &rosetta.AccountIdentifier{
+		subAccountMetadata = &types.AccountIdentifier{
 			Address: "blah",
-			SubAccount: &rosetta.SubAccountIdentifier{
-				SubAccount: "stake",
+			SubAccount: &types.SubAccountIdentifier{
+				Address: "stake",
 				Metadata: &map[string]interface{}{
 					"cool": "hello",
 				},
 			},
 		}
-		subAccountMetadataNewPointer = &rosetta.AccountIdentifier{
+		subAccountMetadataNewPointer = &types.AccountIdentifier{
 			Address: "blah",
-			SubAccount: &rosetta.SubAccountIdentifier{
-				SubAccount: "stake",
+			SubAccount: &types.SubAccountIdentifier{
+				Address: "stake",
 				Metadata: &map[string]interface{}{
 					"cool": "hello",
 				},
 			},
 		}
-		subAccountMetadata2 = &rosetta.AccountIdentifier{
+		subAccountMetadata2 = &types.AccountIdentifier{
 			Address: "blah",
-			SubAccount: &rosetta.SubAccountIdentifier{
-				SubAccount: "stake",
+			SubAccount: &types.SubAccountIdentifier{
+				Address: "stake",
 				Metadata: &map[string]interface{}{
 					"cool": 10,
 				},
 			},
 		}
-		subAccountMetadata2NewPointer = &rosetta.AccountIdentifier{
+		subAccountMetadata2NewPointer = &types.AccountIdentifier{
 			Address: "blah",
-			SubAccount: &rosetta.SubAccountIdentifier{
-				SubAccount: "stake",
+			SubAccount: &types.SubAccountIdentifier{
+				Address: "stake",
 				Metadata: &map[string]interface{}{
 					"cool": 10,
 				},
 			},
 		}
-		currency = &rosetta.Currency{
+		currency = &types.Currency{
 			Symbol:   "BLAH",
 			Decimals: 2,
 		}
-		amount = &rosetta.Amount{
+		amount = &types.Amount{
 			Value:    "100",
 			Currency: currency,
 		}
-		amountNilCurrency = &rosetta.Amount{
+		amountNilCurrency = &types.Amount{
 			Value: "100",
 		}
-		newAmounts = map[string]*rosetta.Amount{
+		newAmounts = map[string]*types.Amount{
 			GetCurrencyKey(currency): amount,
 		}
-		newBlock = &rosetta.BlockIdentifier{
+		newBlock = &types.BlockIdentifier{
 			Hash:  "kdasdj",
 			Index: 123890,
 		}
-		newTransaction = &rosetta.TransactionIdentifier{
+		newTransaction = &types.TransactionIdentifier{
 			Hash: "tx1",
 		}
-		newBlock2 = &rosetta.BlockIdentifier{
+		newBlock2 = &types.BlockIdentifier{
 			Hash:  "pkdasdj",
 			Index: 123890,
 		}
-		newTransaction2 = &rosetta.TransactionIdentifier{
+		newTransaction2 = &types.TransactionIdentifier{
 			Hash: "tx2",
 		}
-		result = map[string]*rosetta.Amount{
+		result = map[string]*types.Amount{
 			GetCurrencyKey(currency): {
 				Value:    "200",
 				Currency: currency,
 			},
 		}
-		newBlock3 = &rosetta.BlockIdentifier{
+		newBlock3 = &types.BlockIdentifier{
 			Hash:  "pkdgdj",
 			Index: 123891,
 		}
-		largeDeduction = &rosetta.Amount{
+		largeDeduction = &types.Amount{
 			Value:    "-1000",
 			Currency: currency,
 		}
@@ -418,7 +418,7 @@ func TestBalance(t *testing.T) {
 			newTransaction,
 		)
 		assert.Equal(t, &BalanceChange{
-			Account: &rosetta.AccountIdentifier{
+			Account: &types.AccountIdentifier{
 				Address: "blah",
 			},
 			Currency:    currency,
@@ -472,7 +472,7 @@ func TestBalance(t *testing.T) {
 			newTransaction2,
 		)
 		assert.Equal(t, &BalanceChange{
-			Account: &rosetta.AccountIdentifier{
+			Account: &types.AccountIdentifier{
 				Address: "blah",
 			},
 			Currency:    currency,
@@ -505,7 +505,7 @@ func TestBalance(t *testing.T) {
 			nil,
 		)
 		assert.Equal(t, &BalanceChange{
-			Account: &rosetta.AccountIdentifier{
+			Account: &types.AccountIdentifier{
 				Address: "blah",
 			},
 			Currency:   currency,
@@ -658,18 +658,18 @@ func TestBalance(t *testing.T) {
 
 func TestGetCurrencyKey(t *testing.T) {
 	var tests = map[string]struct {
-		currency *rosetta.Currency
+		currency *types.Currency
 		key      string
 	}{
 		"simple currency": {
-			currency: &rosetta.Currency{
+			currency: &types.Currency{
 				Symbol:   "BTC",
 				Decimals: 8,
 			},
 			key: "BTC:8",
 		},
 		"currency with string metadata": {
-			currency: &rosetta.Currency{
+			currency: &types.Currency{
 				Symbol:   "BTC",
 				Decimals: 8,
 				Metadata: &map[string]interface{}{
@@ -679,7 +679,7 @@ func TestGetCurrencyKey(t *testing.T) {
 			key: "BTC:8:map[issuer:satoshi]",
 		},
 		"currency with number metadata": {
-			currency: &rosetta.Currency{
+			currency: &types.Currency{
 				Symbol:   "BTC",
 				Decimals: 8,
 				Metadata: &map[string]interface{}{
@@ -689,7 +689,7 @@ func TestGetCurrencyKey(t *testing.T) {
 			key: "BTC:8:map[issuer:1]",
 		},
 		"currency with complex metadata": {
-			currency: &rosetta.Currency{
+			currency: &types.Currency{
 				Symbol:   "BTC",
 				Decimals: 8,
 				Metadata: &map[string]interface{}{
@@ -718,12 +718,12 @@ func createBootstrapBalancesFile(dataDir string) (*os.File, error) {
 
 func TestBootstrapBalances(t *testing.T) {
 	var (
-		genesisBlockIdentifier = &rosetta.BlockIdentifier{
+		genesisBlockIdentifier = &types.BlockIdentifier{
 			Index: 0,
 			Hash:  "0",
 		}
 
-		account = &rosetta.AccountIdentifier{
+		account = &types.AccountIdentifier{
 			Address: "hello",
 		}
 	)
@@ -763,9 +763,9 @@ func TestBootstrapBalances(t *testing.T) {
 		))
 		assert.NoError(t, err)
 
-		amount := &rosetta.Amount{
+		amount := &types.Amount{
 			Value: "10",
-			Currency: &rosetta.Currency{
+			Currency: &types.Currency{
 				Symbol:   "BTC",
 				Decimals: 8,
 			},
@@ -849,9 +849,9 @@ func TestBootstrapBalances(t *testing.T) {
 		))
 		assert.NoError(t, err)
 
-		amount := &rosetta.Amount{
+		amount := &types.Amount{
 			Value: "goodbye",
-			Currency: &rosetta.Currency{
+			Currency: &types.Currency{
 				Symbol:   "BTC",
 				Decimals: 8,
 			},

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -25,28 +25,28 @@ import (
 
 	"github.com/coinbase/rosetta-sdk-go/asserter"
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
-	rosetta "github.com/coinbase/rosetta-sdk-go/gen"
+	"github.com/coinbase/rosetta-sdk-go/types"
 
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	currency = &rosetta.Currency{
+	currency = &types.Currency{
 		Symbol:   "Blah",
 		Decimals: 2,
 	}
 
-	recipient = &rosetta.AccountIdentifier{
+	recipient = &types.AccountIdentifier{
 		Address: "acct1",
 	}
 
-	recipientAmount = &rosetta.Amount{
+	recipientAmount = &types.Amount{
 		Value:    "100",
 		Currency: currency,
 	}
 
-	recipientOperation = &rosetta.Operation{
-		OperationIdentifier: &rosetta.OperationIdentifier{
+	recipientOperation = &types.Operation{
+		OperationIdentifier: &types.OperationIdentifier{
 			Index: 0,
 		},
 		Type:    "Transfer",
@@ -55,8 +55,8 @@ var (
 		Amount:  recipientAmount,
 	}
 
-	recipientFailureOperation = &rosetta.Operation{
-		OperationIdentifier: &rosetta.OperationIdentifier{
+	recipientFailureOperation = &types.Operation{
+		OperationIdentifier: &types.OperationIdentifier{
 			Index: 1,
 		},
 		Type:    "Transfer",
@@ -65,27 +65,27 @@ var (
 		Amount:  recipientAmount,
 	}
 
-	recipientTransaction = &rosetta.Transaction{
-		TransactionIdentifier: &rosetta.TransactionIdentifier{
+	recipientTransaction = &types.Transaction{
+		TransactionIdentifier: &types.TransactionIdentifier{
 			Hash: "tx1",
 		},
-		Operations: []*rosetta.Operation{
+		Operations: []*types.Operation{
 			recipientOperation,
 			recipientFailureOperation,
 		},
 	}
 
-	sender = &rosetta.AccountIdentifier{
+	sender = &types.AccountIdentifier{
 		Address: "acct2",
 	}
 
-	senderAmount = &rosetta.Amount{
+	senderAmount = &types.Amount{
 		Value:    "-100",
 		Currency: currency,
 	}
 
-	senderOperation = &rosetta.Operation{
-		OperationIdentifier: &rosetta.OperationIdentifier{
+	senderOperation = &types.Operation{
+		OperationIdentifier: &types.OperationIdentifier{
 			Index: 0,
 		},
 		Type:    "Transfer",
@@ -94,143 +94,143 @@ var (
 		Amount:  senderAmount,
 	}
 
-	senderTransaction = &rosetta.Transaction{
-		TransactionIdentifier: &rosetta.TransactionIdentifier{
+	senderTransaction = &types.Transaction{
+		TransactionIdentifier: &types.TransactionIdentifier{
 			Hash: "tx2",
 		},
-		Operations: []*rosetta.Operation{
+		Operations: []*types.Operation{
 			senderOperation,
 		},
 	}
 
-	blockSequenceNoReorg = []*rosetta.Block{
+	blockSequenceNoReorg = []*types.Block{
 		{ // genesis
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
 			},
 		},
 		{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "1",
 				Index: 1,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
 			},
 		},
 		{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "2",
 				Index: 2,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "1",
 				Index: 1,
 			},
-			Transactions: []*rosetta.Transaction{
+			Transactions: []*types.Transaction{
 				recipientTransaction,
 			},
 		},
 		{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "3",
 				Index: 3,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "2",
 				Index: 2,
 			},
-			Transactions: []*rosetta.Transaction{
+			Transactions: []*types.Transaction{
 				senderTransaction,
 			},
 		},
 	}
 
-	orphanGenesis = &rosetta.Block{
-		BlockIdentifier: &rosetta.BlockIdentifier{
+	orphanGenesis = &types.Block{
+		BlockIdentifier: &types.BlockIdentifier{
 			Hash:  "1",
 			Index: 1,
 		},
-		ParentBlockIdentifier: &rosetta.BlockIdentifier{
+		ParentBlockIdentifier: &types.BlockIdentifier{
 			Hash:  "0a",
 			Index: 0,
 		},
-		Transactions: []*rosetta.Transaction{},
+		Transactions: []*types.Transaction{},
 	}
 
-	blockSequenceReorg = []*rosetta.Block{
+	blockSequenceReorg = []*types.Block{
 		{ // genesis
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
 			},
 		},
 		{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "1",
 				Index: 1,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
 			},
-			Transactions: []*rosetta.Transaction{
+			Transactions: []*types.Transaction{
 				recipientTransaction,
 			},
 		},
 		{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "2",
 				Index: 2,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "1a",
 				Index: 1,
 			},
 		},
 		{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "1a",
 				Index: 1,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "0",
 				Index: 0,
 			},
 		},
 		{
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "3",
 				Index: 3,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "2",
 				Index: 2,
 			},
 		},
 		{ // invalid block
-			BlockIdentifier: &rosetta.BlockIdentifier{
+			BlockIdentifier: &types.BlockIdentifier{
 				Hash:  "5",
 				Index: 5,
 			},
-			ParentBlockIdentifier: &rosetta.BlockIdentifier{
+			ParentBlockIdentifier: &types.BlockIdentifier{
 				Hash:  "4",
 				Index: 4,
 			},
 		},
 	}
 
-	operationStatuses = []*rosetta.OperationStatus{
+	operationStatuses = []*types.OperationStatus{
 		{
 			Status:     "Success",
 			Successful: true,
@@ -241,19 +241,33 @@ var (
 		},
 	}
 
-	networkStatusResponse = &rosetta.NetworkStatusResponse{
-		NetworkStatus: &rosetta.NetworkStatus{
-			NetworkInformation: &rosetta.NetworkInformation{
-				GenesisBlockIdentifier: &rosetta.BlockIdentifier{
-					Index: 0,
-				},
-				CurrentBlockIdentifier: &rosetta.BlockIdentifier{
-					Index: 1000,
-				},
+	networkStatusResponse = &types.NetworkStatusResponse{
+		GenesisBlockIdentifier: &types.BlockIdentifier{
+			Index: 0,
+			Hash:  "block 0",
+		},
+		CurrentBlockIdentifier: &types.BlockIdentifier{
+			Index: 1000,
+			Hash:  "block 1000",
+		},
+		CurrentBlockTimestamp: 10000,
+		Peers: []*types.Peer{
+			{
+				PeerID: "peer 1",
 			},
 		},
-		Options: &rosetta.Options{
+	}
+
+	networkOptionsResponse = &types.NetworkOptionsResponse{
+		Version: &types.Version{
+			RosettaVersion: "1.3.1",
+			NodeVersion:    "1.0",
+		},
+		Allow: &types.Allow{
 			OperationStatuses: operationStatuses,
+			OperationTypes: []string{
+				"Transfer",
+			},
 		},
 	}
 )
@@ -271,8 +285,16 @@ func TestNoReorgProcessBlock(t *testing.T) {
 
 	blockStorage := storage.NewBlockStorage(ctx, database)
 	logger := logger.NewLogger(*newDir, false, false, false, false)
+	asserter, err := asserter.NewWithResponses(
+		ctx,
+		networkStatusResponse,
+		networkOptionsResponse,
+	)
+	assert.NotNil(t, asserter)
+	assert.NoError(t, err)
+
 	fetcher := &fetcher.Fetcher{
-		Asserter: asserter.New(ctx, networkStatusResponse),
+		Asserter: asserter,
 	}
 	rec := reconciler.New(ctx, nil, blockStorage, fetcher, logger, 1)
 	syncer := New(ctx, nil, blockStorage, fetcher, logger, rec)
@@ -328,7 +350,7 @@ func TestNoReorgProcessBlock(t *testing.T) {
 		assert.Equal(t, int64(3), currIndex)
 		assert.Equal(t, []*storage.BalanceChange{
 			{
-				Account: &rosetta.AccountIdentifier{
+				Account: &types.AccountIdentifier{
 					Address: "acct1",
 				},
 				Currency:    currency,
@@ -350,7 +372,7 @@ func TestNoReorgProcessBlock(t *testing.T) {
 		tx.Discard(ctx)
 
 		// Ensure amount only increases by successful operation
-		assert.Equal(t, map[string]*rosetta.Amount{
+		assert.Equal(t, map[string]*types.Amount{
 			storage.GetCurrencyKey(currency): recipientAmount,
 		}, amounts)
 		assert.Equal(t, blockSequenceNoReorg[2].BlockIdentifier, block)
@@ -418,8 +440,16 @@ func TestReorgProcessBlock(t *testing.T) {
 
 	blockStorage := storage.NewBlockStorage(ctx, database)
 	logger := logger.NewLogger(*newDir, false, false, false, false)
+	asserter, err := asserter.NewWithResponses(
+		ctx,
+		networkStatusResponse,
+		networkOptionsResponse,
+	)
+	assert.NotNil(t, asserter)
+	assert.NoError(t, err)
+
 	fetcher := &fetcher.Fetcher{
-		Asserter: asserter.New(ctx, networkStatusResponse),
+		Asserter: asserter,
 	}
 	rec := reconciler.New(ctx, nil, blockStorage, fetcher, logger, 1)
 	syncer := New(ctx, nil, blockStorage, fetcher, logger, rec)
@@ -480,7 +510,7 @@ func TestReorgProcessBlock(t *testing.T) {
 		assert.Equal(t, int64(2), currIndex)
 		assert.Equal(t, []*storage.BalanceChange{
 			{
-				Account: &rosetta.AccountIdentifier{
+				Account: &types.AccountIdentifier{
 					Address: "acct1",
 				},
 				Currency:    currency,
@@ -500,7 +530,7 @@ func TestReorgProcessBlock(t *testing.T) {
 
 		amounts, block, err := syncer.storage.GetBalance(ctx, tx, recipient)
 		tx.Discard(ctx)
-		assert.Equal(t, map[string]*rosetta.Amount{
+		assert.Equal(t, map[string]*types.Amount{
 			storage.GetCurrencyKey(currency): recipientAmount,
 		}, amounts)
 		assert.Equal(t, blockSequenceReorg[1].BlockIdentifier, block)
@@ -521,7 +551,7 @@ func TestReorgProcessBlock(t *testing.T) {
 		assert.Equal(t, int64(1), currIndex)
 		assert.Equal(t, []*storage.BalanceChange{
 			{
-				Account: &rosetta.AccountIdentifier{
+				Account: &types.AccountIdentifier{
 					Address: "acct1",
 				},
 				Currency:    currency,
@@ -544,7 +574,7 @@ func TestReorgProcessBlock(t *testing.T) {
 
 		// Assert that balance change was reverted
 		// only by the successful operation
-		zeroAmount := map[string]*rosetta.Amount{
+		zeroAmount := map[string]*types.Amount{
 			storage.GetCurrencyKey(currency): {
 				Value:    "0",
 				Currency: currency,

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	var r *reconciler.Reconciler
 	if cfg.ReconcileBalances {
-		log.Printf("Balance reconciliation enabled\n")
+		log.Println("Balance reconciliation enabled")
 
 		r = reconciler.New(
 			ctx,

--- a/main.go
+++ b/main.go
@@ -17,8 +17,6 @@ package main
 import (
 	"context"
 	"log"
-	"net/http"
-	"time"
 
 	"github.com/coinbase/rosetta-validator/internal/logger"
 	"github.com/coinbase/rosetta-validator/internal/reconciler"
@@ -26,7 +24,6 @@ import (
 	"github.com/coinbase/rosetta-validator/internal/syncer"
 
 	"github.com/coinbase/rosetta-sdk-go/fetcher"
-	rosetta "github.com/coinbase/rosetta-sdk-go/gen"
 
 	"github.com/caarlos0/env"
 	"golang.org/x/sync/errgroup"
@@ -43,11 +40,8 @@ type config struct {
 	LogBalances            bool   `env:"LOG_BALANCES,required"`
 	LogReconciliation      bool   `env:"LOG_RECONCILIATION,required"`
 	BootstrapBalances      bool   `env:"BOOTSTRAP_BALANCES,required"`
+	ReconcileBalances      bool   `env:"RECONCILE_BALANCES,required"`
 }
-
-const (
-	defaultHTTPTimeout = 10 * time.Second
-)
 
 func main() {
 	ctx := context.Background()
@@ -60,23 +54,14 @@ func main() {
 	fetcher := fetcher.New(
 		ctx,
 		cfg.ServerURL,
-		"rosetta-validator",
-		&http.Client{
-			Timeout: defaultHTTPTimeout,
-		},
-		cfg.BlockConcurrency,
-		cfg.TransactionConcurrency,
+		fetcher.WithBlockConcurrency(cfg.BlockConcurrency),
+		fetcher.WithTransactionConcurrency(cfg.TransactionConcurrency),
 	)
 
-	networkResponse, err := fetcher.InitializeAsserter(ctx)
+	// TODO: sync and reconcile on subnetworks, if they exist.
+	primaryNetwork, networkStatus, err := fetcher.InitializeAsserter(ctx)
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	// TODO: sync and reconcile on subnetworks, if they exist.
-	network := &rosetta.NetworkIdentifier{
-		Network:    networkResponse.NetworkStatus.NetworkIdentifier.Network,
-		Blockchain: networkResponse.NetworkStatus.NetworkIdentifier.Blockchain,
 	}
 
 	localStore, err := storage.NewBadgerStorage(ctx, cfg.DataDir)
@@ -89,7 +74,7 @@ func main() {
 		err = blockStorage.BootstrapBalances(
 			ctx,
 			cfg.DataDir,
-			networkResponse.NetworkStatus.NetworkInformation.GenesisBlockIdentifier,
+			networkStatus.GenesisBlockIdentifier,
 		)
 		if err != nil {
 			log.Fatal(err)
@@ -107,12 +92,12 @@ func main() {
 	g, ctx := errgroup.WithContext(ctx)
 
 	var r *reconciler.Reconciler
-	if reconciler.ShouldReconcile(networkResponse) {
+	if cfg.ReconcileBalances {
 		log.Printf("Balance reconciliation enabled\n")
 
 		r = reconciler.New(
 			ctx,
-			network,
+			primaryNetwork,
 			blockStorage,
 			fetcher,
 			logger,
@@ -126,7 +111,7 @@ func main() {
 
 	syncer := syncer.New(
 		ctx,
-		network,
+		primaryNetwork,
 		blockStorage,
 		fetcher,
 		logger,


### PR DESCRIPTION
* Update rosetta-validator to use the 1.3.1 release of the Rosetta specification ([using v0.1.4 of the rosetta-sdk-go](https://github.com/coinbase/rosetta-sdk-go/releases/tag/v0.1.4)) 
* make `BALANCE_RECONCILIATION` an optional setting