### PR TITLE
Debug Inactive Reconciliation Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,25 +33,29 @@ Usage:
   rosetta-validator [command]
 
 Available Commands:
+  check:account  Debug inactive reconciliation errors for a group of accounts
   check:complete Run a full check of the correctness of a Rosetta server
   check:quick    Run a simple check of the correctness of a Rosetta server
-  help           Help about any commands
+  help           Help about any command
 
-Global Flags:
-  --account-concurrency uint       concurrency to use while fetching accounts during reconciliation (default 8)
-  --block-concurrency uint         concurrency to use while fetching blocks (default 8)
-  --data-dir string                folder used to store logs and any data used to perform validation (default "./validator-data")
-  --end int                        block index to stop syncing (default -1)
-  --halt-on-reconciliation-error   Determines if block processing should halt on a reconciliation
-                                   error. It can be beneficial to collect all reconciliation errors or silence
-                                   reconciliation errors during development. (default true)
-  --log-balance-changes            log balance changes (default true)
-  --log-blocks                     log processed blocks (default true)
-  --log-reconciliations            log balance reconciliations (default true)
-  --log-transactions               log processed transactions (default true)
-  --server-url string              base URL for a Rosetta server to validate (default "http://localhost:8080")
-  --start int                      block index to start syncing (default -1)
-  --transaction-concurrency uint   concurrency to use while fetching transactions (if required) (default 16)
+Flags:
+      --account-concurrency uint       concurrency to use while fetching accounts during reconciliation (default 8)
+      --block-concurrency uint         concurrency to use while fetching blocks (default 8)
+      --data-dir string                folder used to store logs and any data used to perform validation (default "./validator-data")
+      --end int                        block index to stop syncing (default -1)
+      --halt-on-reconciliation-error   Determines if block processing should halt on a reconciliation
+                                       error. It can be beneficial to collect all reconciliation errors or silence
+                                       reconciliation errors during development. (default true)
+  -h, --help                           help for rosetta-validator
+      --log-balance-changes            log balance changes
+      --log-blocks                     log processed blocks
+      --log-reconciliations            log balance reconciliations
+      --log-transactions               log processed transactions
+      --server-url string              base URL for a Rosetta server to validate (default "http://localhost:8080")
+      --start int                      block index to start syncing (default -1)
+      --transaction-concurrency uint   concurrency to use while fetching transactions (if required) (default 16)
+
+Use "rosetta-validator [command] --help" for more information about a command.
 ```
 
 ### check:complete
@@ -103,7 +107,42 @@ Usage:
 
 Flags:
   -h, --help   help for check:quick
+```
 
+### check:account
+```
+check:complete identifies accounts with inactive reconciliation
+errors (when the balance of an account changes without any operations), however,
+it does not identify which block the untracked balance change occurred. This tool
+is used for locating exactly which block was missing an operation for a
+particular account and currency.
+
+In the future, this tool will be deprecated as check:complete
+will automatically identify the block where the missing operation occurred.
+
+Usage:
+  rosetta-validator check:account [flags]
+
+Flags:
+  -h, --help                          help for check:account
+      --interesting-accounts string   Absolute path to a file listing all accounts to check on each block. Look
+                                      at the examples directory for an example of how to structure this file.
+
+Global Flags:
+      --account-concurrency uint       concurrency to use while fetching accounts during reconciliation (default 8)
+      --block-concurrency uint         concurrency to use while fetching blocks (default 8)
+      --data-dir string                folder used to store logs and any data used to perform validation (default "./validator-data")
+      --end int                        block index to stop syncing (default -1)
+      --halt-on-reconciliation-error   Determines if block processing should halt on a reconciliation
+                                       error. It can be beneficial to collect all reconciliation errors or silence
+                                       reconciliation errors during development. (default true)
+      --log-balance-changes            log balance changes
+      --log-blocks                     log processed blocks
+      --log-reconciliations            log balance reconciliations
+      --log-transactions               log processed transactions
+      --server-url string              base URL for a Rosetta server to validate (default "http://localhost:8080")
+      --start int                      block index to start syncing (default -1)
+      --transaction-concurrency uint   concurrency to use while fetching transactions (if required) (default 16)
 ```
 
 ## Development

--- a/cmd/check_complete.go
+++ b/cmd/check_complete.go
@@ -133,6 +133,7 @@ func runCheckCompleteCmd(cmd *cobra.Command, args []string) {
 	syncHandler := syncer.NewBaseHandler(
 		logger,
 		r,
+		nil,
 	)
 
 	statefulSyncer := syncer.NewStateful(

--- a/cmd/check_complete.go
+++ b/cmd/check_complete.go
@@ -133,7 +133,6 @@ func runCheckCompleteCmd(cmd *cobra.Command, args []string) {
 	syncHandler := syncer.NewBaseHandler(
 		logger,
 		r,
-		nil,
 	)
 
 	statefulSyncer := syncer.NewStateful(

--- a/cmd/check_quick.go
+++ b/cmd/check_quick.go
@@ -83,6 +83,7 @@ func runCheckQuickCmd(cmd *cobra.Command, args []string) {
 		logger,
 		AccountConcurrency,
 		HaltOnReconciliationError,
+		nil,
 	)
 
 	g.Go(func() error {
@@ -92,7 +93,6 @@ func runCheckQuickCmd(cmd *cobra.Command, args []string) {
 	syncHandler := syncer.NewBaseHandler(
 		logger,
 		r,
-		nil,
 	)
 
 	statelessSyncer := syncer.NewStateless(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,25 +125,25 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(
 		&LogBlocks,
 		"log-blocks",
-		true,
+		false,
 		"log processed blocks",
 	)
 	rootCmd.PersistentFlags().BoolVar(
 		&LogTransactions,
 		"log-transactions",
-		true,
+		false,
 		"log processed transactions",
 	)
 	rootCmd.PersistentFlags().BoolVar(
 		&LogBalanceChanges,
 		"log-balance-changes",
-		true,
+		false,
 		"log balance changes",
 	)
 	rootCmd.PersistentFlags().BoolVar(
 		&LogReconciliations,
 		"log-reconciliations",
-		true,
+		false,
 		"log balance reconciliations",
 	)
 	rootCmd.PersistentFlags().BoolVar(
@@ -157,4 +157,5 @@ reconciliation errors during development.`,
 
 	rootCmd.AddCommand(checkCompleteCmd)
 	rootCmd.AddCommand(checkQuickCmd)
+	rootCmd.AddCommand(checkAccountCmd)
 }

--- a/examples/bootstrap_balances.csv
+++ b/examples/bootstrap_balances.csv
@@ -1,2 +1,0 @@
-AccountIdentifier_address,Amount_value,Currency_symbol,Currency_decimals
-1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,5000000000,BTC,8

--- a/examples/bootstrap_balances.json
+++ b/examples/bootstrap_balances.json
@@ -1,0 +1,12 @@
+[
+  {
+    "account_identifier": {
+      "address":"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+    },
+    "currency":{
+      "symbol":"BTC",
+      "decimals":8
+    },
+    "value": "5000000000"
+  }
+]

--- a/examples/interesting_accounts.json
+++ b/examples/interesting_accounts.json
@@ -1,0 +1,11 @@
+[
+  {
+    "account_identifier": {
+      "address":"0x379fC39D8744ED0C1c8BCfd86771338b9086660D"
+    },
+    "currency": {
+      "symbol": "ETH",
+      "decimals": 18
+    }
+  }
+]

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -294,6 +294,15 @@ func (l *Logger) ReconcileFailureStream(
 	difference string,
 	block *types.BlockIdentifier,
 ) error {
+	// Always print out reconciliation failures
+	log.Printf(
+		"%s Reconciliation failed for %+v at %d by %s (computed-node)\n",
+		reconciliationType,
+		account,
+		block.Index,
+		difference,
+	)
+
 	if !l.logReconciliation {
 		return nil
 	}
@@ -307,14 +316,6 @@ func (l *Logger) ReconcileFailureStream(
 		return err
 	}
 	defer f.Close()
-
-	log.Printf(
-		"%s Reconciliation failed for %+v at %d by %s (computed-node)\n",
-		reconciliationType,
-		account,
-		block.Index,
-		difference,
-	)
 
 	_, err = f.WriteString(fmt.Sprintf(
 		"Type:%s Account: %+v Currency: %+v Block: %s:%d Difference(computed-node):%s\n",

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -57,8 +57,8 @@ func ExtractAmount(
 // a *types.Account and *types.Currency. This can
 // be useful for looking up balances.
 type AccountCurrency struct {
-	Account  *types.AccountIdentifier
-	Currency *types.Currency
+	Account  *types.AccountIdentifier `json:"account_identifier,omitempty"`
+	Currency *types.Currency          `json:"currency,omitempty"`
 }
 
 // ContainsAccountCurrency returns a boolean indicating if a

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -30,6 +30,7 @@ import (
 type Reconciler interface {
 	QueueChanges(
 		ctx context.Context,
+		block *types.BlockIdentifier,
 		changes []*storage.BalanceChange,
 	) error
 

--- a/internal/reconciler/stateful_reconciler.go
+++ b/internal/reconciler/stateful_reconciler.go
@@ -137,17 +137,18 @@ func NewStateful(
 // for reconciliation.
 func (r *StatefulReconciler) QueueChanges(
 	ctx context.Context,
+	block *types.BlockIdentifier,
 	balanceChanges []*storage.BalanceChange,
 ) error {
+	// All changes will have the same block. Return
+	// if we are too far behind to start reconciling.
+	if block.Index < r.highWaterMark {
+		return nil
+	}
+
 	// Use a buffered channel so don't need to
 	// spawn a goroutine to add accounts to channel.
 	for _, change := range balanceChanges {
-		// All changes will have the same block. Return
-		// if we are too far behind to start reconciling.
-		if change.Block.Index < r.highWaterMark {
-			return nil
-		}
-
 		select {
 		case r.changeQueue <- change:
 		default:

--- a/internal/syncer/base_handler.go
+++ b/internal/syncer/base_handler.go
@@ -17,7 +17,6 @@ package syncer
 import (
 	"context"
 	"log"
-	"reflect"
 
 	"github.com/coinbase/rosetta-validator/internal/logger"
 	"github.com/coinbase/rosetta-validator/internal/reconciler"
@@ -29,26 +28,24 @@ import (
 // BaseHandler logs processed blocks
 // and reconciles modified balances.
 type BaseHandler struct {
-	logger              *logger.Logger
-	reconciler          reconciler.Reconciler
-	interestingAccounts []*reconciler.AccountCurrency
+	logger     *logger.Logger
+	reconciler reconciler.Reconciler
 }
 
 // NewBaseHandler constructs a basic Handler.
 func NewBaseHandler(
 	logger *logger.Logger,
 	reconciler reconciler.Reconciler,
-	interestingAccounts []*reconciler.AccountCurrency,
 ) Handler {
 	return &BaseHandler{
-		logger:              logger,
-		reconciler:          reconciler,
-		interestingAccounts: interestingAccounts,
+		logger:     logger,
+		reconciler: reconciler,
 	}
 }
 
 // BlockProcessed is called by the syncer after each
 // block is processed.
+// TODO: refactor to BlockAdded and BlockRemoved
 func (h *BaseHandler) BlockProcessed(
 	ctx context.Context,
 	block *types.Block,
@@ -69,33 +66,7 @@ func (h *BaseHandler) BlockProcessed(
 		return nil
 	}
 
-	// TODO: refactor this once handler is cleaned up to remove storage
-	// dependency in syncer
-	for _, account := range h.interestingAccounts {
-		skipAccount := false
-		// Look through balance changes for account + currency
-		for _, change := range balanceChanges {
-			if reflect.DeepEqual(change.Account, account.Account) && reflect.DeepEqual(change.Currency, account.Currency) {
-				skipAccount = true
-				break
-			}
-		}
-
-		// Account changed on this block
-		if skipAccount {
-			continue
-		}
-
-		// If account + currency not found, add with difference 0
-		balanceChanges = append(balanceChanges, &storage.BalanceChange{
-			Account:    account.Account,
-			Currency:   account.Currency,
-			Difference: "0",
-			Block:      block.BlockIdentifier,
-		})
-	}
-
 	// Mark accounts for reconciliation...this may be
 	// blocking
-	return h.reconciler.QueueChanges(ctx, balanceChanges)
+	return h.reconciler.QueueChanges(ctx, block.BlockIdentifier, balanceChanges)
 }

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -145,6 +145,7 @@ func Sync(
 // to handle different events. It is common to write logs or
 // perform reconciliation in the sync handler.
 type Handler interface {
+	// TODO: change to BlockAdded and BlockRemoved
 	BlockProcessed(
 		ctx context.Context,
 		block *types.Block,


### PR DESCRIPTION
### Motivation
When an inactive reconciliation error occurred, it was difficult to debug the error (determine exactly what block was missing an operation).

### Solution
It is now possible to provide a group of accounts to check for missing balance changes.

### Fixes
* Use a JSON file for bootstrap accounts instead of CSV (this allows for properly specifying accounts and currencies)
* Modify logging defaults to be `false` instead of `true`

### Future PR
Refactor the reconciler to return the block that caused an inactive reconciliation error so this command does not need to be run after observing error.

